### PR TITLE
立替参加者削除実行時、テキストフィールドの値が再更新されない不具合を修正

### DIFF
--- a/lib/ui/input_participants/InputParticipantsPage.dart
+++ b/lib/ui/input_participants/InputParticipantsPage.dart
@@ -66,8 +66,11 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Expanded(
-            child: TextFormField(
-                initialValue: _participants[participantIndex].displayName)),
+          child: TextFormField(
+            initialValue: _participants[participantIndex].displayName,
+            key: UniqueKey(),
+          ),
+        ),
         IconButton(
           icon: Icon(Icons.remove, size: 16),
           onPressed: () {


### PR DESCRIPTION
SSIA

## 修正内容

修正前|修正後
---|---
![before](https://user-images.githubusercontent.com/38374045/120910147-5b6b3700-c6b7-11eb-9e8e-3299b6758b0d.gif)|![after](https://user-images.githubusercontent.com/38374045/120910150-60c88180-c6b7-11eb-9794-0680c299cb9b.gif)

## 参考

https://stackoverflow.com/questions/58053956/setstate-does-not-update-textformfield-when-use-initialvalue#