### PR TITLE
ベータ版iOS/Androidアプリの継続的デリバリ追加

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,24 +10,24 @@ pool:
 variables:
 - group: Secrets
 
-steps:
-- task: FlutterInstall@0
-  inputs:
-    channel: 'stable'
-    version: 'latest'
-- script: |
-    echo '$FLUTTERTOOLPATH/flutter pub get'
-    $FLUTTERTOOLPATH/flutter pub get
-    echo '$FLUTTERTOOLPATH/flutter analyze'
-    $FLUTTERTOOLPATH/flutter analyze
-  displayName: 'Flutter Analyze (scratch)'
-- task: FlutterTest@0
-  inputs:
-    projectDirectory: '.'
-- task: FlutterBuild@0
-  inputs:
-    target: 'apk'
-    projectDirectory: '.'
-    buildFlavour: 'dev'
-    buildNumber: '$(Build.BuildId)'
-    entryPoint: 'lib/main_dev.dart'
+stages:
+- stage: qa_stage
+  displayName: 動作検証ステージ
+  condition: always()
+  jobs:
+  - job: analysis_job
+    displayName: 静的解析
+    steps:
+    - task: FlutterInstall@0
+      inputs:
+        channel: 'stable'
+        version: 'latest'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter pub get'
+        $FLUTTERTOOLPATH/flutter pub get
+        echo '>> $FLUTTERTOOLPATH/flutter analyze'
+        $FLUTTERTOOLPATH/flutter analyze
+      displayName: 'Flutter Analyze (scratch)'
+    - task: FlutterTest@0
+      inputs:
+        projectDirectory: '.'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,9 @@ trigger:
 pool:
   vmImage: macos-latest
 
+variables:
+- group: Secrets
+
 steps:
 - task: FlutterInstall@0
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,3 +31,58 @@ stages:
     - task: FlutterTest@0
       inputs:
         projectDirectory: '.'
+- stage: beta_app_deploy_stage
+  displayName: β版アプリ配布ステージ
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/develop')
+  dependsOn: qa_stage
+  jobs:
+  - job: firebase_deploy_job
+    displayName: Firebaseへベータ版アプリ配布
+    steps:
+    - task: FlutterInstall@0
+    - script: |
+        echo '>> gem install bundler:1.17.2'
+        gem install bundler:1.17.2
+      displayName: 'Install bundler'
+    - script: |
+        echo '>> cd ios'
+        cd ios
+        echo '>> bundle install'
+        bundle install
+      displayName: 'Install iOS gem dependency'
+    - script: |
+        echo '>> echo $(GITHUB_ACCESS_TOKEN)@github.com | xargs -I {} sed -i '' s/github.com/{}/ ios/fastlane/Matchfile'
+        echo $(GITHUB_ACCESS_TOKEN)@github.com | xargs -I {} sed -i '' s/github.com/{}/ ios/fastlane/Matchfile
+        echo '>> export MATCH_PASSWORD=$(MATCH_PASSWORD)'
+        export MATCH_PASSWORD='$(MATCH_PASSWORD)'
+      displayName: 'Set configs for fastlane match'
+    - script: |
+        echo '>> cd ios'
+        cd ios
+        echo '>> bundle exec fastlane load_certs'
+        bundle exec fastlane load_certs
+      displayName: 'Fastlane match'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter build ipa --flavor dev -t lib/main_dev.dart --build-number=$(Build.BuildNumber) --export-options-plist=ios/ExportOptions_dev.plist'
+        $FLUTTERTOOLPATH/flutter build ipa --flavor dev -t lib/main_dev.dart --build-number=$(Build.BuildNumber) --export-options-plist=ios/ExportOptions_dev.plist
+      displayName: 'Flutter build dev ipa (scratch)'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter build ipa --flavor prd -t lib/main_prd.dart --build-number=$(Build.BuildNumber) --export-options-plist=ios/ExportOptions_prd.plist'
+        $FLUTTERTOOLPATH/flutter build ipa --flavor prd -t lib/main_prd.dart --build-number=$(Build.BuildNumber) --export-options-plist=ios/ExportOptions_prd.plist
+      displayName: 'Flutter build prd ipa (scratch)'
+    - script: |
+        echo '>> which which npm'
+        which npm
+        echo '>> npm install -g firebase-tools'
+        npm install -g firebase-tools
+        echo '>> which firebase'
+        which firebase
+      displayName: 'Install Firebase tools'
+    - script: |
+        echo '>> ls -latr build/ios/ipa/'
+        ls -latr build/ios/ipa/
+        echo '>> firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)'
+        firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)
+        echo '>> firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD --token $(FIREBASE_TOKEN)'
+        firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD) --token $(FIREBASE_TOKEN)
+      displayName: 'Deploy to Firebase App Distribution'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@ trigger:
 
 pool:
   vmImage: macos-latest
+  demands: xcode
 
 variables:
 - group: Secrets

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,14 @@ stages:
         $FLUTTERTOOLPATH/flutter build ipa --flavor prd -t lib/main_prd.dart --build-number=$(Build.BuildNumber) --export-options-plist=ios/ExportOptions_prd.plist
       displayName: 'Flutter build prd ipa (scratch)'
     - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter build apk --flavor dev -t lib/main_dev.dart --build-number=$(Build.BuildId)'
+        $FLUTTERTOOLPATH/flutter build apk --flavor dev -t lib/main_dev.dart --build-number=$(Build.BuildId)
+      displayName: 'Flutter build dev apk (scratch)'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter build apk --flavor prd -t lib/main_prd.dart --build-number=$(Build.BuildId)'
+        $FLUTTERTOOLPATH/flutter build apk --flavor prd -t lib/main_prd.dart --build-number=$(Build.BuildId)
+      displayName: 'Flutter build prd apk (scratch)'
+    - script: |
         echo '>> which which npm'
         which npm
         echo '>> npm install -g firebase-tools'
@@ -81,8 +89,14 @@ stages:
     - script: |
         echo '>> ls -latr build/ios/ipa/'
         ls -latr build/ios/ipa/
+        echo '>> ls -latr build/app/outputs/flutter-apk'
+        ls -latr build/app/outputs/flutter-apk
         echo '>> firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)'
         firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)
         echo '>> firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD --token $(FIREBASE_TOKEN)'
         firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD) --token $(FIREBASE_TOKEN)
+        echo '>> firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)'
+        firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)
+        echo '>> firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD --token $(FIREBASE_TOKEN)'
+        firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD) --token $(FIREBASE_TOKEN)
       displayName: 'Deploy to Firebase App Distribution'

--- a/ios/ExportOptions_dev.plist
+++ b/ios/ExportOptions_dev.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<true/>
+	<key>destination</key>
+	<string>export</string>
+	<key>method</key>
+	<string>ad-hoc</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.ntetz.flutter.tatetsu.dev</key>
+		<string>match AdHoc com.ntetz.flutter.tatetsu.dev</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>K85M397W48</string>
+	<key>thinning</key>
+	<string>&lt;none&gt;</string>
+</dict>
+</plist>

--- a/ios/ExportOptions_prd.plist
+++ b/ios/ExportOptions_prd.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>compileBitcode</key>
+	<true/>
+	<key>destination</key>
+	<string>export</string>
+	<key>method</key>
+	<string>ad-hoc</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.ntetz.flutter.tatetsu</key>
+		<string>match AdHoc com.ntetz.flutter.tatetsu</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>Apple Distribution</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>teamID</key>
+	<string>K85M397W48</string>
+	<key>thinning</key>
+	<string>&lt;none&gt;</string>
+</dict>
+</plist>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -21,6 +21,8 @@ platform :ios do
 
   desc "provisioning profile読み取りlane"
   lane :load_certs do
+    setup_ci
+
     match(
       app_identifier: [
         APP_IDENTIFIER_DEVELOP,


### PR DESCRIPTION
## 概要

毎回ケーブル繋いでテストするのだるいので自動化。
iOSはFastlane Matchでadhoc署名、Androidはデバッグ署名でバイナリを投げている

## 参考

下記ドキュメントが大変参考になった。

### iOS ( ipa )

https://medium.com/flutter-jp/ipa-e176de0276c6
https://medium.com/karlmax-berlin/versioning-with-flutter-299869e68af4
https://stackoverflow.com/questions/62333770/flutter-pipeline-in-azure-devops

#### iOS ( Fastlane match + Azure Pipeline )

https://github.com/fastlane/fastlane/discussions/16831#discussioncomment-37993
https://docs.fastlane.tools/actions/setup_ci/

http://blog.syati.info/post/node_path/

### Android ( apk )

https://qiita.com/rkowase/items/f1012ef0738791dd6084 (結局デバッグ署名で妥協したのでここまではやっていない)

### Firebase CLI

https://firebase.google.com/docs/cli#windows-npm
http://blog.syati.info/post/node_path/
https://firebase.google.com/docs/app-distribution/ios/distribute-cli
