### PR TITLE
会計入力画面のUI追加

### DIFF
--- a/lib/model/entity/payment.dart
+++ b/lib/model/entity/payment.dart
@@ -1,0 +1,13 @@
+import 'package:tatetsu/model/entity/participant.dart';
+
+class Payment {
+  String title = "Some Payment";
+  Participant payer;
+  double price = 0.0;
+  List<Participant> participants;
+  Map<Participant, bool> owners = {};
+
+  Payment({required this.participants})
+      : payer = participants.first,
+        owners = Map.fromIterables(participants, participants.map((_) => true));
+}

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -74,6 +74,24 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   List<Widget> _payerView(PaymentComponent payment) {
     return [
       const Text("Payer"),
+      DropdownButton<Participant>(
+        value: payment.data.payer,
+        onChanged: (Participant? newValue) {
+          setState(() {
+            if (newValue == null) {
+              return;
+            }
+            payment.data.payer = newValue;
+          });
+        },
+        items: payment.data.participants
+            .map<DropdownMenuItem<Participant>>((Participant value) {
+          return DropdownMenuItem<Participant>(
+            value: value,
+            child: Text(value.displayName),
+          );
+        }).toList(),
+      ),
     ];
   }
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -33,6 +33,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               );
             }
             return ExpansionPanelList(
+              key: UniqueKey(),
               expansionCallback: (int index, bool isExpanded) {
                 setState(() {
                   widget.payments[index].isExpanded = !isExpanded;

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -26,6 +26,12 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         ),
         body: ListView.builder(
           itemBuilder: (BuildContext context, int index) {
+            if (index == 1) {
+              return TextButton(
+                onPressed: _insertPaymentToLast,
+                child: const Icon(Icons.add_circle_sharp, size: 32),
+              );
+            }
             return ExpansionPanelList(
               expansionCallback: (int index, bool isExpanded) {
                 setState(() {
@@ -44,8 +50,14 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               }).toList(),
             );
           },
-          itemCount: 1,
+          itemCount: 2, // 入力部分と追加ボタンで、合計2
         ));
+  }
+
+  void _insertPaymentToLast() {
+    setState(() {
+      widget.payments.add(PaymentComponent(participants: widget.participants));
+    });
   }
 
   ListTile _paymentHeader(PaymentComponent payment) {

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -67,8 +67,9 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   Column _paymentEditBody(PaymentComponent payment) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
-      children:
-          [_payerView(payment), _priceView(payment)].expand((e) => e).toList(),
+      children: [_payerView(payment), _priceView(payment), _ownerView(payment)]
+          .expand((e) => e)
+          .toList(),
     );
   }
 
@@ -105,5 +106,29 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         key: UniqueKey(),
       ),
     ];
+  }
+
+  List<Widget> _ownerView(PaymentComponent payment) {
+    final headerComponent = [
+      const SizedBox(height: 16),
+      const Text("Owners"),
+    ];
+    final ownersComponent = payment.data.owners.entries
+        .map((e) => Row(children: [
+              Checkbox(
+                value: e.value,
+                onChanged: (bool? value) {
+                  setState(() {
+                    if (value == null) {
+                      return;
+                    }
+                    payment.data.owners[e.key] = value;
+                  });
+                },
+              ),
+              Text(e.key.displayName)
+            ]))
+        .toList();
+    return [headerComponent, ownersComponent].expand((e) => e).toList();
   }
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -67,7 +67,8 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   Column _paymentEditBody(PaymentComponent payment) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [_payerView(payment)].expand((e) => e).toList(),
+      children:
+          [_payerView(payment), _priceView(payment)].expand((e) => e).toList(),
     );
   }
 
@@ -91,6 +92,17 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
             child: Text(value.displayName),
           );
         }).toList(),
+      ),
+    ];
+  }
+
+  List<Widget> _priceView(PaymentComponent payment) {
+    return [
+      const SizedBox(height: 16),
+      const Text("Price"),
+      TextFormField(
+        initialValue: payment.data.price.toString(),
+        key: UniqueKey(),
       ),
     ];
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -5,7 +5,7 @@ import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 class InputAccountingDetailPage extends StatefulWidget {
   InputAccountingDetailPage({required this.participants})
       : payments = [
-          PaymentComponent(participants: participants)
+          PaymentComponent(participants: participants)..isExpanded = true
         ],
         super();
 

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,10 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
-  const InputAccountingDetailPage({required this.participants}) : super();
+  InputAccountingDetailPage({required this.participants})
+      : payments = [
+          PaymentComponent(participants: participants)
+        ],
+        super();
 
   final List<Participant> participants;
+  final List<PaymentComponent> payments;
 
   @override
   _InputAccountingDetailPageState createState() =>
@@ -18,6 +24,56 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         appBar: AppBar(
           title: const Text("Input Accounting Detail"),
         ),
-        body: Text(widget.participants.map((e) => e.displayName).toString()));
+        body: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            return ExpansionPanelList(
+              expansionCallback: (int index, bool isExpanded) {
+                setState(() {
+                  widget.payments[index].isExpanded = !isExpanded;
+                });
+              },
+              children: widget.payments
+                  .map<ExpansionPanel>((PaymentComponent payment) {
+                return ExpansionPanel(
+                  headerBuilder: (BuildContext _, bool __) {
+                    return _paymentHeader(payment);
+                  },
+                  body: _paymentBody(payment),
+                  isExpanded: payment.isExpanded,
+                );
+              }).toList(),
+            );
+          },
+          itemCount: 1,
+        ));
+  }
+
+  ListTile _paymentHeader(PaymentComponent payment) {
+    return ListTile(
+      title: TextFormField(
+        initialValue: payment.data.title,
+        key: UniqueKey(),
+      ),
+    );
+  }
+
+  Container _paymentBody(PaymentComponent payment) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 16, horizontal: 16),
+      child: _paymentEditBody(payment),
+    );
+  }
+
+  Column _paymentEditBody(PaymentComponent payment) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [_payerView(payment)].expand((e) => e).toList(),
+    );
+  }
+
+  List<Widget> _payerView(PaymentComponent payment) {
+    return [
+      const Text("Payer"),
+    ];
   }
 }

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -1,0 +1,10 @@
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+
+class PaymentComponent {
+  bool isExpanded = false;
+  Payment data;
+
+  PaymentComponent({required List<Participant> participants})
+      : data = Payment(participants: participants);
+}


### PR DESCRIPTION
## 概要

- 摘要
- 建替担当者
- 支払い責任者
- 金額

をもったコンポーネントを入力できるようにしました。

## 変更概要

変更前|変更後
---|---
![before](https://user-images.githubusercontent.com/38374045/129466800-1132446e-281e-47d4-ba78-d8bf8ec1faf4.gif)|![after](https://user-images.githubusercontent.com/38374045/129466676-b7eecfc6-16c0-4aaf-881b-83863ebd8a3b.gif)

## 参考

下記記事が大変参考になった

### 開閉可能なリスト

https://api.flutter.dev/flutter/material/ExpansionPanelList-class.html

#### 開いている時の要素追加時の不具合

https://github.com/flutter/flutter/issues/13780#issuecomment-696618329

### ドロップダウン

https://api.flutter.dev/flutter/material/DropdownButton-class.html

### チェックボックス

https://api.flutter.dev/flutter/material/Checkbox-class.html

### コレクション操作

https://qiita.com/7_asupara/items/01c29c006556e89f5b17
https://stackoverflow.com/questions/15413248/how-to-flatten-a-list

### 余白

https://www.rm48.net/post/flutter-dart-textの余白を調整する