### PR TITLE
立替費合算計算用の処理を追加

### DIFF
--- a/lib/model/core/no_debtors_exception.dart
+++ b/lib/model/core/no_debtors_exception.dart
@@ -1,0 +1,1 @@
+class NoDebtorsException implements Exception {}

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -1,0 +1,43 @@
+import 'package:tatetsu/model/core/no_debtors_exception.dart';
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+
+class Creditor {
+  Map<Participant, double> entries;
+
+  Creditor({required List<Payment> payments})
+      : entries = payments.toCreditorEntries();
+}
+
+extension PaymentsExt on List<Payment> {
+  Map<Participant, double> toCreditorEntries() {
+    final Map<Participant, double> creditorEntries = Map.fromIterables(
+        first.owners.keys, List.generate(first.owners.length, (_) => 0));
+    forEach((payment) => creditorEntries.apply(payment));
+    return creditorEntries;
+  }
+}
+
+extension CreditorEntriesExt on Map<Participant, double> {
+  void apply(Payment payment) {
+    _addCredit(payment);
+    _addDebut(payment);
+  }
+
+  void _addCredit(Payment payment) =>
+      update(payment.payer, (value) => value += payment.price);
+
+  void _addDebut(Payment payment) {
+    final List<Participant> debtors = payment.owners.entries
+        .where((element) => element.value)
+        .map((e) => e.key)
+        .toList();
+    if (debtors.isEmpty) {
+      throw NoDebtorsException();
+    }
+    final fee = payment.price / debtors.length;
+    for (final debtor in debtors) {
+      update(debtor, (value) => value -= fee);
+    }
+  }
+}

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -1,0 +1,9 @@
+import 'package:tatetsu/model/entity/creditor.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+
+class Transaction {
+  Creditor creditor;
+
+  Transaction({required List<Payment> payments})
+      : creditor = Creditor(payments: payments);
+}

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/entity/payment.dart';
+import 'package:tatetsu/model/entity/transaction.dart';
 
 class SettleAccountsPage extends StatefulWidget {
   const SettleAccountsPage({required this.payments}) : super();
@@ -17,6 +18,11 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         appBar: AppBar(
           title: const Text("Settle Accounts Result"),
         ),
-        body: Text(widget.payments.map((e) => e.title).toString()));
+        body: Text(Transaction(payments: widget.payments)
+            .creditor
+            .entries
+            .entries
+            .map((e) => "\nperson: ${e.key.displayName}, credit: ${e.value}\n")
+            .join()));
   }
 }

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -1,0 +1,550 @@
+import 'package:tatetsu/model/entity/creditor.dart';
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Creditor', () {
+    test('PaymentsExt_toCreditorEntries_Paymentが空の時、エラー', () {
+      final List<Payment> testPayments = [];
+
+      expect(() => testPayments.toCreditorEntries(), throwsStateError);
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが1つの時立替額の合計値が0', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments
+              .toCreditorEntries()
+              .values
+              .reduce((current, next) => current + next),
+          equals(0.0));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが1つの時立替額が均等割される', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments.toCreditorEntries(),
+          equals({
+            testParticipant1: 4000.0,
+            testParticipant2: -2000.0,
+            testParticipant3: -2000.0
+          }));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが2つの時立替額の合計値が0', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments
+              .toCreditorEntries()
+              .values
+              .reduce((current, next) => current + next),
+          equals(0.0));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが2つの時立替額が2会計の合算', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          Creditor(payments: testPayments).entries,
+          equals({
+            testParticipant1: 4000.0,
+            testParticipant2: -1550.0,
+            testParticipant3: -2450.0
+          }));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが3つの時立替額の合計値が0', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 30000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments
+              .toCreditorEntries()
+              .values
+              .reduce((current, next) => current + next),
+          equals(0.0));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentが3つの時立替額が3会計の合算', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 30000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments.toCreditorEntries(),
+          equals({
+            testParticipant1: -6000.0,
+            testParticipant2: -11550.0,
+            testParticipant3: 17550.0
+          }));
+    });
+
+    test('PaymentsExt_toCreditorEntries_Paymentに割り切れない値がある時、小数点まで含んだ合算値', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 40000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          testPayments.toCreditorEntries(),
+          equals({
+            testParticipant1: -9333.333333333334,
+            testParticipant2: -14883.333333333334,
+            testParticipant3: 24216.666666666664
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者1人支払者1人のPaymentを与えた時、0円の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final creditorEntries = {testParticipant1: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: true});
+
+      expect(
+          creditorEntries..apply(testPayment), equals({testParticipant1: 0.0}));
+    });
+
+    test('CreditorEntriesExt_apply_参加者1人支払者0人のPaymentを与えた時、例外', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final creditorEntries = {testParticipant1: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: false});
+
+      expect(() => creditorEntries..apply(testPayment), throwsException);
+    });
+
+    test('CreditorEntriesExt_apply_参加者2人支払者2人のPaymentを与えた時、半額移動の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final creditorEntries = {testParticipant1: 0.0, testParticipant2: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: true, testParticipant2: true});
+
+      expect(creditorEntries..apply(testPayment),
+          equals({testParticipant1: 3000.0, testParticipant2: -3000.0}));
+    });
+
+    test(
+        'CreditorEntriesExt_apply_参加者2人支払者2人のPaymentを、予め値を持つ立替に与えた時、半額移動の立替が追加',
+        () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final creditorEntries = {
+        testParticipant1: -500.0,
+        testParticipant2: 500.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: true, testParticipant2: true});
+
+      expect(creditorEntries..apply(testPayment),
+          equals({testParticipant1: 2500.0, testParticipant2: -2500.0}));
+    });
+
+    test('CreditorEntriesExt_apply_参加者2人支払者1人(立替者)のPaymentを与えた時、0円の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final creditorEntries = {testParticipant1: 0.0, testParticipant2: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: true, testParticipant2: false});
+
+      expect(creditorEntries..apply(testPayment),
+          equals({testParticipant1: 0.0, testParticipant2: 0.0}));
+    });
+
+    test('CreditorEntriesExt_apply_参加者2人支払者1人(非立替者)のPaymentを与えた時、全額移動の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final creditorEntries = {testParticipant1: 0.0, testParticipant2: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: false, testParticipant2: true});
+
+      expect(creditorEntries..apply(testPayment),
+          equals({testParticipant1: 6000.0, testParticipant2: -6000.0}));
+    });
+
+    test('CreditorEntriesExt_apply_参加者2人支払者0人のPaymentを与えた時、例外', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final creditorEntries = {testParticipant1: 0.0, testParticipant2: 0.0};
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {testParticipant1: false, testParticipant2: false});
+
+      expect(() => creditorEntries..apply(testPayment), throwsException);
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者3人のPaymentを与えた時、1/3額移動の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 4000.0,
+            testParticipant2: -2000.0,
+            testParticipant3: -2000.0
+          }));
+    });
+
+    test(
+        'CreditorEntriesExt_apply_参加者3人支払者3人のPaymentを、予め値を持つ立替に与えた時、1/3額移動の立替が追加',
+        () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: -200.0,
+        testParticipant2: -200.0,
+        testParticipant3: 400.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 3800.0,
+            testParticipant2: -2200.0,
+            testParticipant3: -1600.0
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者2人(立替者含む)のPaymentを与えた時、半額移動の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: false
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 3000.0,
+            testParticipant2: -3000.0,
+            testParticipant3: 0.0
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者2人(立替者含まず)のPaymentを与えた時、合計全額移動の立替',
+        () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: false,
+            testParticipant2: true,
+            testParticipant3: true
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 6000.0,
+            testParticipant2: -3000.0,
+            testParticipant3: -3000.0
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者1人(立替者)のPaymentを与えた時、0円の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: false,
+            testParticipant3: false
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 0.0,
+            testParticipant2: 0.0,
+            testParticipant3: 0.0
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者1人(非立替者)のPaymentを与えた時、全額移動の立替', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: false,
+            testParticipant2: true,
+            testParticipant3: false
+          });
+
+      expect(
+          creditorEntries..apply(testPayment),
+          equals({
+            testParticipant1: 6000.0,
+            testParticipant2: -6000.0,
+            testParticipant3: 0.0
+          }));
+    });
+
+    test('CreditorEntriesExt_apply_参加者3人支払者0人のPaymentを与えた時、例外', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final creditorEntries = {
+        testParticipant1: 0.0,
+        testParticipant2: 0.0,
+        testParticipant3: 0.0
+      };
+      final testPayment = Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: false,
+            testParticipant2: false,
+            testParticipant3: false
+          });
+
+      expect(() => creditorEntries..apply(testPayment), throwsException);
+    });
+  });
+}

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -1,0 +1,152 @@
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+import 'package:tatetsu/model/entity/transaction.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Transaction', () {
+    test('Transaction_creditor属性が、Paymentが1つの時立替額が均等割される', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          Transaction(payments: testPayments).creditor.entries,
+          equals({
+            testParticipant1: 4000.0,
+            testParticipant2: -2000.0,
+            testParticipant3: -2000.0
+          }));
+    });
+
+    test('Transaction_creditor属性が、Paymentが2つの時立替額が2会計の合算', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+      expect(
+          Transaction(payments: testPayments).creditor.entries,
+          equals({
+            testParticipant1: 4000.0,
+            testParticipant2: -1550.0,
+            testParticipant3: -2450.0
+          }));
+    });
+
+    test('Transaction_creditor属性が、Paymentが3つの時立替額が3会計の合算', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 30000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          Transaction(payments: testPayments).creditor.entries,
+          equals({
+            testParticipant1: -6000.0,
+            testParticipant2: -11550.0,
+            testParticipant3: 17550.0
+          }));
+    });
+
+    test('Transaction_creditor属性が、Paymentに割り切れない値がある時、小数点まで含んだ合算値', () {
+      final Participant testParticipant1 = Participant("testName1");
+      final Participant testParticipant2 = Participant("testName2");
+      final Participant testParticipant3 = Participant("testName3");
+      final List<Payment> testPayments = [
+        Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 6000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 900,
+            owners: {
+              testParticipant1: false,
+              testParticipant2: true,
+              testParticipant3: true
+            }),
+        Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 40000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true
+            })
+      ];
+
+      expect(
+          Transaction(payments: testPayments).creditor.entries,
+          equals({
+            testParticipant1: -9333.333333333334,
+            testParticipant2: -14883.333333333334,
+            testParticipant3: 24216.666666666664
+          }));
+    });
+  });
+}

--- a/test/ui/input_accounting_detail/payment_component_test.dart
+++ b/test/ui/input_accounting_detail/payment_component_test.dart
@@ -18,6 +18,10 @@ void main() {
           equals(testParticipant1));
     });
 
+    test('PaymentComponent_引数に空配列を渡すとエラー', () {
+      expect(() => PaymentComponent(participants: []), throwsStateError);
+    });
+
     test('PaymentComponent_owners属性に、引数で渡した値に対してtrueのハッシュマップが設定される', () {
       final Participant testParticipant1 = Participant("testName1");
       final Participant testParticipant2 = Participant("testName2");


### PR DESCRIPTION
## 概要

支払いを集計して、立替費の合算を出すためのモデルを追加

## 参考

下記が参考になった。

### コレクション操作

https://qiita.com/7_asupara/items/01c29c006556e89f5b17
https://qiita.com/lacolaco/items/99554704b4d4733eed6d

### 例外・エラー

https://dart.dev/samples#exceptions
https://api.dart.dev/stable/2.10.4/dart-core/Error-class.html
https://api.dart.dev/stable/2.10.4/dart-core/Exception-class.html
https://zenn.dev/iwaku/articles/2020-12-19-iwaku

### ユニットテストでの例外・エラー

https://qiita.com/kasa_le/items/bf48b65fdb8cf1fa0421