### PR TITLE
立替参加者画面のバグ修正諸々

### DIFF
--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -93,6 +93,9 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
           child: TextFormField(
             initialValue: _participants[participantIndex].displayName,
             key: UniqueKey(),
+            onChanged: (String value) {
+              _participants[participantIndex].displayName = value;
+            },
           ),
         ),
         TextButton(

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -85,6 +85,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
   }
 
   Row _createParticipantInputArea(int participantIndex) {
+    final bool hasOnlyParticipants = _participants.length <= 1;
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
@@ -95,9 +96,9 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
           ),
         ),
         TextButton(
-          onPressed: () {
-            _removeParticipant(participantIndex);
-          },
+          onPressed: hasOnlyParticipants
+              ? null
+              : () => {_removeParticipant(participantIndex)},
           child: const Icon(
             Icons.remove,
             size: 16,


### PR DESCRIPTION
## 概要

立替参加者を0人にできてしまう現象（後にゼロ除算で落ちる）と、立替参加者の編集後の名前を引き継げない不具合を修正