### PR TITLE
精算額に小数点3桁目以降が含まれないようにした

### DIFF
--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -25,7 +25,13 @@ class Creditor {
     }
 
     // 絶対値の大きなものが基準とされてしまい、払い過ぎや貰い過ぎが発生してややこしくなってしまうのを防ぎたい
-    final double dealValue = min(debt.abs(), credit.abs());
+    final double dealTarget = min(debt.abs(), credit.abs());
+
+    // 精算額はドルにおけるセントまでと考え、0.01を下限とする。誤差は別途表示する
+    final double dealValue = dealTarget.floorAtSecondDecimal();
+    if (dealValue == 0) {
+      return null;
+    }
     entries.update(from, (value) => value += dealValue);
     entries.update(to, (value) => value -= dealValue);
     return Settlement(from: from, to: to, amount: dealValue);
@@ -49,6 +55,10 @@ extension PaymentsExt on List<Payment> {
     forEach((payment) => creditorEntries.apply(payment));
     return creditorEntries;
   }
+}
+
+extension DoubleExt on double {
+  double floorAtSecondDecimal() => this == 0 ? 0 : (this * 100).floor() / 100;
 }
 
 extension CreditorEntriesExt on Map<Participant, double> {

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -194,6 +194,48 @@ void main() {
           true);
     });
 
+    test('extractSettlement_精算対象が0.01未満の時、nullで、プロパティに影響を与えない', () {
+      final testEntries = {
+        testParticipant1: -21.00999999999999999,
+        testParticipant2: 0.00999999999999999,
+        testParticipant3: 21.0,
+      };
+      final testCreditor = Creditor(payments: dummyPayments)
+        ..entries = testEntries;
+
+      expect(
+          testCreditor.extractSettlement(
+              from: testParticipant1, to: testParticipant2),
+          null);
+      expect(mapEquals(testCreditor.entries, testEntries), true);
+    });
+
+    test(
+        'extractSettlement_精算対象が0.01未満の値が含まれる浮動小数点の時、誤差の含まれる精算となり、プロパティに当該の精算結果が適用される',
+        () {
+      final testEntries = {
+        testParticipant1: -28.009999999999997,
+        testParticipant2: 28.009999999999998,
+        testParticipant3: -0.000000000000001,
+      };
+      final testCreditor = Creditor(payments: dummyPayments)
+        ..entries = testEntries;
+
+      expect(
+          testCreditor
+              .extractSettlement(from: testParticipant1, to: testParticipant2)!
+              .isEqualTo(Settlement(
+                  from: testParticipant1, to: testParticipant2, amount: 28.01)),
+          equals(true));
+      expect(
+          mapEquals(testCreditor.entries, {
+            testParticipant1: 3.552713678800501e-15,
+            testParticipant2: -3.552713678800501e-15,
+            testParticipant3: -1e-15,
+          }),
+          true);
+    });
+
     test('getCreditors_立替額0が1人の時、空配列', () {
       expect(
           (Creditor(payments: dummyPayments)..entries = {...oneZeroEntry})
@@ -569,6 +611,18 @@ void main() {
             testParticipant2: -14883.333333333334,
             testParticipant3: 24216.666666666664
           }));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_0の時、0', () {
+      expect(0.0.floorAtSecondDecimal(), equals(0));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる、0', () {
+      expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る、0', () {
+      expect(28.009999999999997.floorAtSecondDecimal(), equals(28.01));
     });
 
     test('CreditorEntriesExt_apply_参加者1人支払者1人のPaymentを与えた時、0円の立替', () {


### PR DESCRIPTION
## 概要

SSIA

## 変更詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148639275-763f44ee-d2e7-4dea-aff5-aa5201b3ac6f.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148639265-85dee09d-7e68-4665-8fde-48456135e583.png">

## 参考

小数点の切り捨て周り、下記が参考になった。

https://dev-yakuza.posstree.com/flutter/dart/ceil-floor-round/