### PR TITLE
CI修理

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,7 @@ stages:
     steps:
     - task: FlutterInstall@0
       inputs:
+        mode: 'auto'
         channel: 'stable'
         version: 'latest'
     - script: |
@@ -40,6 +41,10 @@ stages:
     displayName: Firebaseへベータ版アプリ配布
     steps:
     - task: FlutterInstall@0
+      inputs:
+        mode: 'auto'
+        channel: 'stable'
+        version: 'latest'
     - script: |
         echo '>> gem install bundler:1.17.2'
         gem install bundler:1.17.2

--- a/lib/model/usecase/participants_usecase.dart
+++ b/lib/model/usecase/participants_usecase.dart
@@ -2,11 +2,11 @@ import 'package:english_words/english_words.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 
 class ParticipantsUsecase {
-  static List<Participant> getDefaults() {
+  List<Participant> getDefaults() {
     return [Participant("Alice"), Participant("Bob"), Participant("Charley")];
   }
 
-  static Participant createDummy() {
+  Participant createDummy() {
     final displayName =
         ["Dr.", generateWordPairs().first.asUpperCase].join(" ");
     return Participant(displayName);

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -13,7 +13,7 @@ class InputParticipantsPage extends StatefulWidget {
 }
 
 class _InputParticipantsPageState extends State<InputParticipantsPage> {
-  final List<Participant> _participants = ParticipantsUsecase.getDefaults();
+  final List<Participant> _participants = ParticipantsUsecase().getDefaults();
 
   @override
   Widget build(BuildContext context) {
@@ -47,7 +47,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
 
   void _insertParticipantToLast() {
     setState(() {
-      _participants.add(ParticipantsUsecase.createDummy());
+      _participants.add(ParticipantsUsecase().createDummy());
     });
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -409,4 +409,4 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   cupertino_icons: ^0.1.3

--- a/test/model/usecase/participants_usecase_test.dart
+++ b/test/model/usecase/participants_usecase_test.dart
@@ -4,12 +4,13 @@ import 'package:test/test.dart';
 void main() {
   group('ParticipantsUsecase', () {
     test('getDefaults_デフォルトで3名分設定されていること', () {
-      expect(ParticipantsUsecase.getDefaults().map((e) => e.displayName),
+      expect(ParticipantsUsecase().getDefaults().map((e) => e.displayName),
           equals(["Alice", "Bob", "Charley"]));
     });
 
     test('createDummy_Dr.から始まる名前が設定されていること', () {
-      expect(ParticipantsUsecase.createDummy().displayName, startsWith("Dr."));
+      expect(
+          ParticipantsUsecase().createDummy().displayName, startsWith("Dr."));
     });
   });
 }


### PR DESCRIPTION
## 概要

Azure Pipelineで利用するFlutterが2.2.1より上がらなくなってしまっていたため、Extensionを更新

## 備考

Azure Pipeline管理画面より、古いExtensionは削除している。

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/38374045/148650799-39185719-bdc5-48db-9160-0b07816ff74b.png">

## 参考

下記が参考になった。

https://github.com/aloisdeniel/vsts-flutter-tasks/issues/89