### PR TITLE
立替明細入力画面UI改善諸々

### DIFF
--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -161,7 +161,8 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
           payment.price =
               value.isNotEmpty ? double.parse(value) : paymentPriceHintValue;
         },
-        keyboardType: TextInputType.number,
+        keyboardType:
+            const TextInputType.numberWithOptions(decimal: true),
       ),
     ];
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -93,12 +93,13 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   ListTile _paymentHeader(PaymentComponent payment) {
+    final String paymentTitleHint = payment.title;
     return ListTile(
       title: TextFormField(
-        initialValue: payment.title,
+        decoration: InputDecoration(hintText: paymentTitleHint),
         key: UniqueKey(),
         onChanged: (String value) {
-          payment.title = value;
+          payment.title = value.isNotEmpty ? value : paymentTitleHint;
         },
       ),
     );
@@ -148,14 +149,16 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   List<Widget> _priceView(PaymentComponent payment) {
+    final double paymentPriceHintValue = payment.price;
     return [
       const SizedBox(height: 16),
       const Text("Price"),
       TextFormField(
-        initialValue: payment.price.toString(),
+        decoration: InputDecoration(hintText: paymentPriceHintValue.toString()),
         key: UniqueKey(),
         onChanged: (String value) {
-          payment.price = double.parse(value);
+          payment.price =
+              value.isNotEmpty ? double.parse(value) : paymentPriceHintValue;
         },
         keyboardType: TextInputType.number,
       ),

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -144,6 +144,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
             child: Text(value.displayName),
           );
         }).toList(),
+        isExpanded: true,
       ),
     ];
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -5,9 +5,7 @@ import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
   InputAccountingDetailPage({required this.participants})
-      : payments = [
-          PaymentComponent(participants: participants)..isInputBodyExpanded = true
-        ],
+      : payments = [PaymentComponent(participants: participants)],
         super();
 
   final List<Participant> participants;

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -6,7 +6,7 @@ import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 class InputAccountingDetailPage extends StatefulWidget {
   InputAccountingDetailPage({required this.participants})
       : payments = [
-          PaymentComponent(participants: participants)..isExpanded = true
+          PaymentComponent(participants: participants)..isInputBodyExpanded = true
         ],
         super();
 
@@ -44,11 +44,12 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               child: const Icon(Icons.add_circle_sharp, size: 32),
             );
           }
+
           return ExpansionPanelList(
             key: UniqueKey(),
             expansionCallback: (int index, bool isExpanded) {
               setState(() {
-                widget.payments[index].isExpanded = !isExpanded;
+                widget.payments[index].isInputBodyExpanded = !isExpanded;
               });
             },
             children:
@@ -58,7 +59,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
                   return _paymentHeader(payment);
                 },
                 body: _paymentBody(payment),
-                isExpanded: payment.isExpanded,
+                isExpanded: payment.isInputBodyExpanded,
               );
             }).toList(),
           );
@@ -161,18 +162,13 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
           payment.price =
               value.isNotEmpty ? double.parse(value) : paymentPriceHintValue;
         },
-        keyboardType:
-            const TextInputType.numberWithOptions(decimal: true),
+        keyboardType: const TextInputType.numberWithOptions(decimal: true),
       ),
     ];
   }
 
   List<Widget> _ownerView(PaymentComponent payment) {
-    final headerComponent = [
-      const SizedBox(height: 16),
-      const Text("Owners"),
-    ];
-    final ownersComponent = payment.owners.entries
+    final checkBoxComponent = payment.owners.entries
         .map(
           (e) => Row(
             children: [
@@ -192,7 +188,27 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
           ),
         )
         .toList();
-    return [headerComponent, ownersComponent].expand((e) => e).toList();
+
+    final ownersComponent = ExpansionPanelList(
+      expansionCallback: (int index, bool isExpanded) {
+        setState(() {
+          payment.isOwnerChoiceBodyExpanded = !isExpanded;
+        });
+      },
+      children: [
+        ExpansionPanel(
+          headerBuilder: (BuildContext context, bool isExpanded) {
+            return const ListTile(title: Text("Exclude Participants"));
+          },
+          body: Column(
+            children: checkBoxComponent,
+          ),
+          isExpanded: payment.isOwnerChoiceBodyExpanded,
+        )
+      ],
+    );
+
+    return [ownersComponent];
   }
 
   List<Widget> _deleteView(PaymentComponent payment) {

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -2,7 +2,7 @@ import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 
 class PaymentComponent {
-  bool isInputBodyExpanded = false;
+  bool isInputBodyExpanded = true;
   bool isOwnerChoiceBodyExpanded = false;
 
   String title = "Some Payment";

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -2,7 +2,8 @@ import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 
 class PaymentComponent {
-  bool isExpanded = false;
+  bool isInputBodyExpanded = false;
+  bool isOwnerChoiceBodyExpanded = false;
 
   String title = "Some Payment";
   Participant payer;


### PR DESCRIPTION
## 概要

より少ない指の操作で、会計明細が入力できるようにしたり、デザイン調整したり

## 変更内容詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148665670-35912deb-d315-4163-bae0-e1898f5d744a.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148665665-487008d6-587e-47f8-9f22-4027cba81b19.png">



