### PR TITLE
入力域以外をタップした時にソフトウェアキーボードが閉じるようにした

### DIFF
--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -19,50 +19,53 @@ class InputAccountingDetailPage extends StatefulWidget {
 class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Input Accounting Detail"),
-        actions: <Widget>[
-          TextButton(
-            style: TextButton.styleFrom(
-              primary: Theme.of(context).colorScheme.onPrimary,
-            ),
-            onPressed: () {
-              _toSettleAccounts();
-            },
-            child: const Text("Settle"),
-          )
-        ],
-      ),
-      body: ListView.builder(
-        itemBuilder: (BuildContext context, int index) {
-          if (index == 1) {
-            return TextButton(
-              onPressed: _insertPaymentToLast,
-              child: const Icon(Icons.add_circle_sharp, size: 32),
-            );
-          }
-
-          return ExpansionPanelList(
-            key: UniqueKey(),
-            expansionCallback: (int index, bool isExpanded) {
-              setState(() {
-                widget.payments[index].isInputBodyExpanded = !isExpanded;
-              });
-            },
-            children:
-                widget.payments.map<ExpansionPanel>((PaymentComponent payment) {
-              return ExpansionPanel(
-                headerBuilder: (BuildContext _, bool __) {
-                  return _paymentHeader(payment);
-                },
-                body: _paymentBody(payment),
-                isExpanded: payment.isInputBodyExpanded,
+    return GestureDetector(
+      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text("Input Accounting Detail"),
+          actions: <Widget>[
+            TextButton(
+              style: TextButton.styleFrom(
+                primary: Theme.of(context).colorScheme.onPrimary,
+              ),
+              onPressed: () {
+                _toSettleAccounts();
+              },
+              child: const Text("Settle"),
+            )
+          ],
+        ),
+        body: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            if (index == 1) {
+              return TextButton(
+                onPressed: _insertPaymentToLast,
+                child: const Icon(Icons.add_circle_sharp, size: 32),
               );
-            }).toList(),
-          );
-        },
-        itemCount: 2, // 入力部分と追加ボタンで、合計2
+            }
+
+            return ExpansionPanelList(
+              key: UniqueKey(),
+              expansionCallback: (int index, bool isExpanded) {
+                setState(() {
+                  widget.payments[index].isInputBodyExpanded = !isExpanded;
+                });
+              },
+              children: widget.payments
+                  .map<ExpansionPanel>((PaymentComponent payment) {
+                return ExpansionPanel(
+                  headerBuilder: (BuildContext _, bool __) {
+                    return _paymentHeader(payment);
+                  },
+                  body: _paymentBody(payment),
+                  isExpanded: payment.isInputBodyExpanded,
+                );
+              }).toList(),
+            );
+          },
+          itemCount: 2, // 入力部分と追加ボタンで、合計2
+        ),
       ),
     );
   }

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -17,32 +17,35 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-        actions: <Widget>[
-          TextButton(
-            style: TextButton.styleFrom(
-              primary: Theme.of(context).colorScheme.onPrimary,
-            ),
-            onPressed: () {
-              _toInputAccounting();
+    return GestureDetector(
+      onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: Text(widget.title),
+          actions: <Widget>[
+            TextButton(
+              style: TextButton.styleFrom(
+                primary: Theme.of(context).colorScheme.onPrimary,
+              ),
+              onPressed: () {
+                _toInputAccounting();
+              },
+              child: const Icon(Icons.payment, size: 32),
+            )
+          ],
+        ),
+        body: Center(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemBuilder: (BuildContext context, int index) {
+              if (index >= _participants.length) {
+                return _createFooter();
+              }
+              return _createParticipantInputArea(index);
             },
-            child: const Icon(Icons.payment, size: 32),
-          )
-        ],
-      ),
-      body: Center(
-        child: ListView.builder(
-          padding: const EdgeInsets.all(16),
-          itemBuilder: (BuildContext context, int index) {
-            if (index >= _participants.length) {
-              return _createFooter();
-            }
-            return _createParticipantInputArea(index);
-          },
-          // 要素の数は、参加者の数 + ヘッダー1つ
-          itemCount: _participants.length + 1,
+            // 要素の数は、参加者の数 + ヘッダー1つ
+            itemCount: _participants.length + 1,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## 概要

SSIA

## 参考

下記が参考になった。

https://stackoverflow.com/questions/51652897/how-to-hide-soft-input-keyboard-on-flutter-after-clicking-outside-textfield-anyw

今回の場合、ListView中TextFormFieldだからか、
 `FocusScope.of(context).unfocus()` を使った実装にすると、TextFormFieldの2回目以降のタップにおいて、キーボードが自動的に閉じてしまう。

https://ecolife-lab.info/flutter-keyboard/
https://www.choge-blog.com/programming/flutterkeyboard-closebutton/