### PR TITLE
アイコン周りのUI更新諸々

### DIFF
--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -14,7 +14,7 @@ class Tatetsu extends StatelessWidget {
         primarySwatch: Colors.red,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const InputParticipantsPage(title: '[Dev] Input Participants'),
+      home: const InputParticipantsPage(title: '[Dev] Participants'),
     );
   }
 }

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -14,7 +14,7 @@ class Tatetsu extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const InputParticipantsPage(title: 'Input Participants'),
+      home: const InputParticipantsPage(title: 'Participants'),
     );
   }
 }

--- a/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
+++ b/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
+
+class ExcludeParticipantsDialog extends StatefulWidget {
+  final PaymentComponent payment;
+
+  const ExcludeParticipantsDialog({required this.payment}) : super();
+
+  @override
+  State<StatefulWidget> createState() => _ExcludeParticipantsDialogState();
+}
+
+class _ExcludeParticipantsDialogState extends State<ExcludeParticipantsDialog> {
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+        title: const Text("Exclude Participants"),
+        content: SingleChildScrollView(
+          child: _checkBoxComponent(),
+        ),
+        actions: [
+          TextButton(
+            child: const Text("OK"),
+            onPressed: () => Navigator.pop(context),
+          )
+        ],
+      );
+
+  Column _checkBoxComponent() => Column(
+        children: widget.payment.owners.entries
+            .map(
+              (e) => Row(
+                children: [
+                  Checkbox(
+                    value: e.value,
+                    onChanged: (bool? value) {
+                      setState(() {
+                        if (value == null) {
+                          return;
+                        }
+                        widget.payment.owners[e.key] = value;
+                      });
+                    },
+                  ),
+                  Text(e.key.displayName)
+                ],
+              ),
+            )
+            .toList(),
+      );
+}

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -44,7 +44,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
                   children: [
                     TextButton(
                       onPressed: _insertPaymentToLast,
-                      child: const Icon(Icons.add_circle_sharp, size: 32),
+                      child: const Icon(Icons.add_circle, size: 32),
                     )
                   ],
                 ),

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
@@ -126,8 +127,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       children: [
         _payerView(payment),
         _priceView(payment),
-        _ownerView(payment),
-        _deleteView(payment)
+        _actionsView(payment),
       ].expand((e) => e).toList(),
     );
   }
@@ -174,62 +174,27 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     ];
   }
 
-  List<Widget> _ownerView(PaymentComponent payment) {
-    final checkBoxComponent = payment.owners.entries
-        .map(
-          (e) => Row(
-            children: [
-              Checkbox(
-                value: e.value,
-                onChanged: (bool? value) {
-                  setState(() {
-                    if (value == null) {
-                      return;
-                    }
-                    payment.owners[e.key] = value;
-                  });
-                },
-              ),
-              Text(e.key.displayName)
-            ],
-          ),
-        )
-        .toList();
-
-    final ownersComponent = ExpansionPanelList(
-      expansionCallback: (int index, bool isExpanded) {
-        setState(() {
-          payment.isOwnerChoiceBodyExpanded = !isExpanded;
-        });
-      },
-      children: [
-        ExpansionPanel(
-          headerBuilder: (BuildContext context, bool isExpanded) {
-            return const ListTile(title: Text("Exclude Participants"));
-          },
-          body: Column(
-            children: checkBoxComponent,
-          ),
-          isExpanded: payment.isOwnerChoiceBodyExpanded,
-        )
-      ],
-    );
-
-    return [ownersComponent];
-  }
-
-  List<Widget> _deleteView(PaymentComponent payment) {
+  List<Widget> _actionsView(PaymentComponent payment) {
     final bool isOnlyPayment = widget.payments.length <= 1;
     return [
-      Center(
-        child: Wrap(
-          children: [
-            TextButton(
-              onPressed: isOnlyPayment ? null : () => {_deletePayment(payment)},
-              child: const Text("Delete this payment."),
-            )
-          ],
-        ),
+      const SizedBox(height: 16),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          TextButton(
+            onPressed: () {
+              showDialog(
+                context: context,
+                builder: (_) => ExcludeParticipantsDialog(payment: payment),
+              );
+            },
+            child: const Icon(Icons.person_off, size: 32),
+          ),
+          TextButton(
+            onPressed: isOnlyPayment ? null : () => {_deletePayment(payment)},
+            child: const Icon(Icons.delete_forever, size: 32),
+          ),
+        ],
       )
     ];
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -24,7 +24,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
         appBar: AppBar(
-          title: const Text("Input Accounting Detail"),
+          title: const Text("Payments"),
           actions: <Widget>[
             TextButton(
               style: TextButton.styleFrom(

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -56,7 +56,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               key: UniqueKey(),
               expansionCallback: (int index, bool isExpanded) {
                 setState(() {
-                  widget.payments[index].isInputBodyExpanded = !isExpanded;
+                  widget.payments[index].isExpanded = !isExpanded;
                 });
               },
               children: widget.payments
@@ -66,7 +66,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
                     return _paymentHeader(payment);
                   },
                   body: _paymentBody(payment),
-                  isExpanded: payment.isInputBodyExpanded,
+                  isExpanded: payment.isExpanded,
                 );
               }).toList(),
             );

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -39,9 +39,15 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         body: ListView.builder(
           itemBuilder: (BuildContext context, int index) {
             if (index == 1) {
-              return TextButton(
-                onPressed: _insertPaymentToLast,
-                child: const Icon(Icons.add_circle_sharp, size: 32),
+              return Center(
+                child: Wrap(
+                  children: [
+                    TextButton(
+                      onPressed: _insertPaymentToLast,
+                      child: const Icon(Icons.add_circle_sharp, size: 32),
+                    )
+                  ],
+                ),
               );
             }
 
@@ -215,9 +221,15 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   List<Widget> _deleteView(PaymentComponent payment) {
     final bool isOnlyPayment = widget.payments.length <= 1;
     return [
-      TextButton(
-        onPressed: isOnlyPayment ? null : () => {_deletePayment(payment)},
-        child: const Text("Delete this payment."),
+      Center(
+        child: Wrap(
+          children: [
+            TextButton(
+              onPressed: isOnlyPayment ? null : () => {_deletePayment(payment)},
+              child: const Text("Delete this payment."),
+            )
+          ],
+        ),
       )
     ];
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -33,7 +33,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               onPressed: () {
                 _toSettleAccounts();
               },
-              child: const Text("Settle"),
+              child: const Icon(Icons.summarize, size: 32),
             )
           ],
         ),

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -2,8 +2,7 @@ import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 
 class PaymentComponent {
-  bool isInputBodyExpanded = true;
-  bool isOwnerChoiceBodyExpanded = false;
+  bool isExpanded = true;
 
   String title = "Some Payment";
   Participant payer;

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -30,7 +30,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
               onPressed: () {
                 _toInputAccounting();
               },
-              child: const Icon(Icons.payment, size: 32),
+              child: const Icon(Icons.receipt_long, size: 32),
             )
           ],
         ),

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -68,7 +68,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
           children: [
             TextButton(
               onPressed: _insertParticipantToLast,
-              child: const Icon(Icons.add_circle, size: 32),
+              child: const Icon(Icons.person_add, size: 32),
             )
           ],
         ),
@@ -107,8 +107,8 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
               ? null
               : () => {_removeParticipant(participantIndex)},
           child: const Icon(
-            Icons.remove,
-            size: 16,
+            Icons.person_remove,
+            size: 32,
             color: Colors.grey,
           ),
         ),

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -63,11 +63,14 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
     });
   }
 
-  Container _createFooter() => Container(
-        padding: const EdgeInsets.symmetric(vertical: 16),
-        child: TextButton(
-          onPressed: _insertParticipantToLast,
-          child: const Icon(Icons.add_circle, size: 32),
+  Widget _createFooter() => Center(
+        child: Wrap(
+          children: [
+            TextButton(
+              onPressed: _insertParticipantToLast,
+              child: const Icon(Icons.add_circle, size: 32),
+            )
+          ],
         ),
       );
 

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -28,7 +28,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text("Settle Accounts Result"),
+        title: const Text("Credit Summaries"),
       ),
       body: Text([creditorsText, "\n\n", dealsText].join()),
     );

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -5,6 +5,6 @@ import 'package:tatetsu/main_dev.dart';
 void main() {
   testWidgets('Participants label test', (WidgetTester tester) async {
     await tester.pumpWidget(Tatetsu());
-    expect(find.byIcon(Icons.add_circle), findsOneWidget);
+    expect(find.byIcon(Icons.person_add), findsOneWidget);
   });
 }


### PR DESCRIPTION
## 概要

アイコンを見やすくしたり押しやすくしたりした。
また、一画面の中のタイポグラフィの量が少なくなるように調整。

## 変更内容詳細

### 参加者入力画面

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738513-2d307cfc-d005-4014-8d25-7fb384968809.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738381-95dc8e4c-9d84-4c0d-babb-50ed4b96c1bf.png">

### 会計明細入力画面(精算対象者選択非表示)

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738551-a90e47ac-69ba-42dc-9558-1c415035dcc2.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738443-881248ad-ad78-4211-b900-967c29f1b862.png">

### 会計明細入力画面(精算対象者選択非表示)

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738631-9f73649d-c93d-4525-ab16-375fe9a2a9a3.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148738474-e27a43ff-401f-46a4-b370-25649efd4a74.png">

## 参考

下記が参考になった

### アイコンの余白

結局Wrapで対応したので、余白を除去する方法自体は利用せず

https://api.flutter.dev/flutter/widgets/Wrap-class.html
https://qiita.com/mkosuke/items/e506256515179d0f421b#ink
https://flutteragency.com/remove-iconbutton-big-padding/
https://api.flutter.dev/flutter/material/IconButton-class.html

### マテリアルアイコン

https://api.flutter.dev/flutter/material/Icons-class.html

### ダイアログ基本

https://qiita.com/coka__01/items/4c1aea5fb1646e463f91
https://api.flutter.dev/flutter/material/AlertDialog-class.html

### チェックボックスを持つダイアログ

https://stackoverflow.com/questions/61591441/flutter-checkbox-did-not-work-in-alertdialog