### PR TITLE
破壊的な動作の時、確認ダイアログを出すようにした

### DIFF
--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -191,11 +191,38 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
             child: const Icon(Icons.person_off, size: 32),
           ),
           TextButton(
-            onPressed: isOnlyPayment ? null : () => {_deletePayment(payment)},
+            onPressed: isOnlyPayment
+                ? null
+                : () => showDialog(
+                      context: context,
+                      builder: (context) =>
+                          _paymentDeleteConfirmDialog(payment),
+                    ),
             child: const Icon(Icons.delete_forever, size: 32),
           ),
         ],
       )
     ];
   }
+
+  AlertDialog _paymentDeleteConfirmDialog(PaymentComponent payment) =>
+      AlertDialog(
+        content: Text('Are you sure to delete payment \n"${payment.title}"?'),
+        actions: [
+          TextButton(
+            style: TextButton.styleFrom(
+              primary: Theme.of(context).disabledColor,
+            ),
+            onPressed: () => Navigator.pop(context),
+            child: const Text("Cancel"),
+          ),
+          TextButton(
+            onPressed: () {
+              _deletePayment(payment);
+              Navigator.pop(context);
+            },
+            child: const Text("Delete"),
+          )
+        ],
+      );
 }

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 
@@ -15,4 +16,17 @@ class PaymentComponent {
 
   Payment toPayment() =>
       Payment(title: title, payer: payer, price: price, owners: owners);
+}
+
+extension PaymentComponentsExt on List<PaymentComponent> {
+  bool hasOnlyDefaultElements({required List<Participant> onParticipants}) {
+    if (length != 1) {
+      return false;
+    }
+    final defaultElement = PaymentComponent(participants: onParticipants);
+    return first.title == defaultElement.title &&
+        first.payer == defaultElement.payer &&
+        first.price == defaultElement.price &&
+        mapEquals(first.owners, defaultElement.owners);
+  }
 }

--- a/test/ui/input_accounting_detail/payment_component_test.dart
+++ b/test/ui/input_accounting_detail/payment_component_test.dart
@@ -52,5 +52,95 @@ void main() {
         equals("Modified Test Payment"),
       );
     });
+
+    test(
+        'PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つでプロパティがデフォルトと同じ時true',
+        () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+            ..title = "Some Payment"
+            ..payer = testParticipant1
+            ..price = 0.0
+            ..owners = {testParticipant1: true, testParticipant2: true}
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        true,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで支払名が異なる時false',
+        () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+            ..title = "modified title"
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        false,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで支払者が異なる時false',
+        () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+            ..payer = testParticipant2
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        false,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで価格が異なる時false', () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+            ..price = 0.01
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        false,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで精算対象者が異なる時false',
+        () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+            ..owners = {testParticipant1: true, testParticipant2: false}
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        false,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つだが参加者が異なる時false',
+        () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+        ].hasOnlyDefaultElements(onParticipants: [testParticipant1]),
+        false,
+      );
+    });
+
+    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が2以上の時false', () {
+      expect(
+        [
+          PaymentComponent(participants: [testParticipant1, testParticipant2]),
+          PaymentComponent(participants: [testParticipant1, testParticipant2])
+        ].hasOnlyDefaultElements(
+          onParticipants: [testParticipant1, testParticipant2],
+        ),
+        false,
+      );
+    });
   });
 }


### PR DESCRIPTION
## 概要

会計明細入力画面における会計の削除や、入力後画面からの戻るに対してアラートを追加

## 参考

下記が参考になった

### アラート上のチェックボックス

https://stackoverflow.com/questions/61591441/flutter-checkbox-did-not-work-in-alertdialog

### アラート上のキャンセルボタンの文字色

https://github.com/flutter/flutter/issues/2037
https://api.flutter.dev/flutter/material/MaterialButton/disabledTextColor.html
https://api.flutter.dev/flutter/material/ColorScheme-class.html

### 戻るボタンでのアラート表示

https://medium.com/@iamatul_k/flutter-handle-back-button-in-a-flutter-application-override-back-arrow-button-in-app-bar-d17e0a3d41f