### PR TITLE
参加者名が長すぎる時、表示が不正になる現象を修正

### DIFF
--- a/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
+++ b/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
@@ -41,7 +41,13 @@ class _ExcludeParticipantsDialogState extends State<ExcludeParticipantsDialog> {
                       });
                     },
                   ),
-                  Text(e.key.displayName)
+                  Expanded(
+                    child: Text(
+                      e.key.displayName,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  )
                 ],
               ),
             )

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -177,7 +177,11 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
             .map<DropdownMenuItem<Participant>>((Participant value) {
           return DropdownMenuItem<Participant>(
             value: value,
-            child: Text(value.displayName),
+            child: Text(
+              value.displayName,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
           );
         }).toList(),
         isExpanded: true,


### PR DESCRIPTION
## 概要

SSIA

## 変更詳細

### 会計明細入力画面プルダウン

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148776050-82f1313f-80d0-4da9-af9b-1d33a007f023.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148775787-e982520d-bdd5-40d6-980a-77c14226bcfe.png">

### 立替参加者編集ダイアログ

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148776006-9f41d747-e053-4336-9e94-6cb266c9611b.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148775889-6ded680b-3011-4b21-a604-3bba4e6c6026.png">


## 参考

下記が参考になった

https://stackoverflow.com/questions/44579918/flutter-wrap-text-on-overflow-like-insert-ellipsis-or-fade