### PR TITLE
精算画面に、精算、立替、支払の3つが揃ったUIで表示されるようにした

### DIFF
--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,11 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/model/entity/creditor.dart';
+import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
+import 'package:tatetsu/model/entity/settlement.dart';
 import 'package:tatetsu/model/entity/transaction.dart';
 
 class SettleAccountsPage extends StatefulWidget {
-  const SettleAccountsPage({required this.payments}) : super();
+  SettleAccountsPage({required this.payments})
+      : transaction = Transaction(payments),
+        super();
 
   final List<Payment> payments;
+  final Transaction transaction;
 
   @override
   _SettleAccountsPageState createState() => _SettleAccountsPageState();
@@ -13,24 +19,168 @@ class SettleAccountsPage extends StatefulWidget {
 
 class _SettleAccountsPageState extends State<SettleAccountsPage> {
   @override
-  Widget build(BuildContext context) {
-    final Transaction transaction = Transaction(widget.payments);
-    final String creditorsText = transaction.creditor.entries.entries
-        .map((e) => "\nperson: ${e.key.displayName}, credit: ${e.value}\n")
-        .join();
-    final String dealsText = transaction
-        .getSettlements()
-        .map(
-          (e) =>
-              "\nfrom: ${e.from.displayName}, to: ${e.to.displayName}, price: ${e.amount}\n",
-        )
-        .join();
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: const Text("Credit Summaries"),
+        ),
+        body: ListView.builder(
+          itemBuilder: (BuildContext context, int index) {
+            return ExpansionPanelList(
+              key: UniqueKey(),
+              expansionCallback: (int index, bool isExpanded) {
+                setState(() {});
+              },
+              children: [
+                ExpansionPanel(
+                  headerBuilder: (_, __) =>
+                      const ListTile(title: Text("Settlement")),
+                  body: ListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: widget.transaction
+                        .getSettlements()
+                        .map((e) => _settlementComponent(e))
+                        .toList(),
+                  ),
+                  isExpanded: true,
+                ),
+                ExpansionPanel(
+                  headerBuilder: (_, __) =>
+                      const ListTile(title: Text("Creditors")),
+                  body: ListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: widget.transaction.creditor.entries.entries
+                        .toList()
+                        .map((e) => _creditorComponent(e))
+                        .toList(),
+                  ),
+                  isExpanded: true,
+                ),
+                ExpansionPanel(
+                  headerBuilder: (_, __) =>
+                      const ListTile(title: Text("Payments")),
+                  body: ListView(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    children: widget.transaction.payments
+                        .map((e) => _paymentComponent(e))
+                        .toList(),
+                  ),
+                  isExpanded: true,
+                ),
+              ],
+            );
+          },
+          itemCount: 1,
+        ),
+      );
 
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text("Credit Summaries"),
-      ),
-      body: Text([creditorsText, "\n\n", dealsText].join()),
-    );
-  }
+  Column _settlementComponent(Settlement settlement) => Column(
+        children: [
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              const SizedBox(width: 48),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  settlement.from.displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              const Expanded(
+                child: Icon(Icons.arrow_right),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(settlement.to.displayName),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  settlement.amount.toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                ),
+              ),
+              const SizedBox(width: 64),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      );
+
+  Column _creditorComponent(MapEntry<Participant, double> creditorEntry) =>
+      Column(
+        children: [
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const SizedBox(width: 48),
+              Expanded(
+                flex: 5,
+                child: Text(
+                  creditorEntry.key.displayName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  creditorEntry.value.floorAtSecondDecimal().toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                ),
+              ),
+              const SizedBox(width: 64),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      );
+
+  Column _paymentComponent(Payment payment) => Column(
+        children: [
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              const SizedBox(width: 48),
+              Expanded(
+                flex: 3,
+                child: Text(
+                  payment.title,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  payment.payer.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  payment.price.floorAtSecondDecimal().toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                ),
+              ),
+              const SizedBox(width: 64),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      );
 }


### PR DESCRIPTION
## 概要

精算画面に表示するデータを整理

## 変更内容詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148778618-e108f7d0-cbce-49b1-bbdc-6b8325bb5bf6.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148778552-95b818b4-f8fc-4844-8848-aa5514bfec82.png">

## 参考

下記が参考になった

### ListView in ListView

https://qiita.com/code-cutlass/items/3a8b759056db1e8f7639

### 行の中でのFlex

https://api.flutter.dev/flutter/widgets/Expanded-class.html

### マテリアルアイコン

https://api.flutter.dev/flutter/material/Icons-class.html