### PR TITLE
精算画面に桁数切り替えや誤差を表示するための準備の精算画面周りのデザイン更新

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,8 +21,10 @@ stages:
     - task: FlutterInstall@0
       inputs:
         mode: 'auto'
-        channel: 'stable'
-        version: 'latest'
+        #　TODO: Material Oneが入ったバージョンがstableになったらstableにする
+        channel: 'beta'
+        version: 'custom'
+        customVersion: '2.9.0-0.1.pre'
     - script: |
         echo '>> $FLUTTERTOOLPATH/flutter pub get'
         $FLUTTERTOOLPATH/flutter pub get
@@ -43,8 +45,10 @@ stages:
     - task: FlutterInstall@0
       inputs:
         mode: 'auto'
-        channel: 'stable'
-        version: 'latest'
+        #　TODO: Material Oneが入ったバージョンがstableになったらstableにする
+        channel: 'beta'
+        version: 'custom'
+        customVersion: '2.9.0-0.1.pre'
     - script: |
         echo '>> gem install bundler:1.17.2'
         gem install bundler:1.17.2

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -162,7 +162,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
 
   List<Widget> _payerView(PaymentComponent payment) {
     return [
-      const Text("Payer"),
+      Text("Payer", style: Theme.of(context).textTheme.labelMedium),
       DropdownButton<Participant>(
         value: payment.payer,
         onChanged: (Participant? newValue) {
@@ -193,7 +193,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     final double paymentPriceHintValue = payment.price;
     return [
       const SizedBox(height: 16),
-      const Text("Price"),
+      Text("Price", style: Theme.of(context).textTheme.labelMedium),
       TextFormField(
         decoration: InputDecoration(hintText: paymentPriceHintValue.toString()),
         key: UniqueKey(),

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -94,7 +94,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              const SizedBox(width: 48),
+              const SizedBox(width: 16),
               Expanded(
                 flex: 3,
                 child: Text(
@@ -120,7 +120,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                   textAlign: TextAlign.end,
                 ),
               ),
-              const SizedBox(width: 64),
+              const SizedBox(width: 16),
             ],
           ),
           const SizedBox(height: 8),
@@ -133,7 +133,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           const SizedBox(height: 8),
           Row(
             children: [
-              const SizedBox(width: 48),
+              const SizedBox(width: 16),
               Expanded(
                 flex: 5,
                 child: Text(
@@ -151,7 +151,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                   textAlign: TextAlign.end,
                 ),
               ),
-              const SizedBox(width: 64),
+              const SizedBox(width: 16),
             ],
           ),
           const SizedBox(height: 8),
@@ -164,7 +164,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              const SizedBox(width: 48),
+              const SizedBox(width: 16),
               Expanded(
                 flex: 2,
                 child: Text(
@@ -189,7 +189,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                   textAlign: TextAlign.end,
                 ),
               ),
-              const SizedBox(width: 64),
+              const SizedBox(width: 16),
             ],
           ),
           const SizedBox(height: 8),

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -23,56 +23,65 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         appBar: AppBar(
           title: const Text("Credit Summaries"),
         ),
-        body: ListView.builder(
-          itemBuilder: (BuildContext context, int index) {
-            return ExpansionPanelList(
-              key: UniqueKey(),
-              expansionCallback: (int index, bool isExpanded) {
-                setState(() {});
-              },
-              children: [
-                ExpansionPanel(
-                  headerBuilder: (_, __) =>
-                      const ListTile(title: Text("Settlement")),
-                  body: ListView(
+        body: ListView(
+          children: [
+            Card(
+              child: Column(
+                children: [
+                  const ListTile(
+                    title: Text(
+                      "Settlements",
+                    ),
+                  ),
+                  ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     children: widget.transaction
                         .getSettlements()
                         .map((e) => _settlementComponent(e))
                         .toList(),
+                  )
+                ],
+              ),
+            ),
+            Card(
+              child: Column(
+                children: [
+                  const ListTile(
+                    title: Text(
+                      "Creditors",
+                    ),
                   ),
-                  isExpanded: true,
-                ),
-                ExpansionPanel(
-                  headerBuilder: (_, __) =>
-                      const ListTile(title: Text("Creditors")),
-                  body: ListView(
+                  ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     children: widget.transaction.creditor.entries.entries
                         .toList()
                         .map((e) => _creditorComponent(e))
                         .toList(),
+                  )
+                ],
+              ),
+            ),
+            Card(
+              child: Column(
+                children: [
+                  const ListTile(
+                    title: Text(
+                      "Payments",
+                    ),
                   ),
-                  isExpanded: true,
-                ),
-                ExpansionPanel(
-                  headerBuilder: (_, __) =>
-                      const ListTile(title: Text("Payments")),
-                  body: ListView(
+                  ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
                     children: widget.transaction.payments
                         .map((e) => _paymentComponent(e))
                         .toList(),
-                  ),
-                  isExpanded: true,
-                ),
-              ],
-            );
-          },
-          itemCount: 1,
+                  )
+                ],
+              ),
+            ),
+          ],
         ),
       );
 

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -36,6 +36,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                     children: widget.transaction.payments
                         .map((e) => _paymentComponent(e))
                         .toList(),
+                  ),
+                  const SizedBox(
+                    height: 16,
                   )
                 ],
               ),
@@ -52,6 +55,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                         .toList()
                         .map((e) => _creditorComponent(e))
                         .toList(),
+                  ),
+                  const SizedBox(
+                    height: 16,
                   )
                 ],
               ),
@@ -68,6 +74,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                         .getSettlements()
                         .map((e) => _settlementComponent(e))
                         .toList(),
+                  ),
+                  const SizedBox(
+                    height: 16,
                   )
                 ],
               ),

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -29,6 +29,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               child: Column(
                 children: [
                   _titleComponent("Payments"),
+                  _labelComponent("Items"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -43,6 +44,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               child: Column(
                 children: [
                   _titleComponent("Creditors"),
+                  _labelComponent("Balance"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -58,6 +60,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               child: Column(
                 children: [
                   _titleComponent("Settlements"),
+                  _labelComponent("Procedures"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -78,6 +81,23 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           title,
           style: Theme.of(context).textTheme.titleLarge,
         ),
+      );
+
+  Column _labelComponent(String label) => Column(
+        children: [
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              const SizedBox(width: 16),
+              Text(
+                label,
+                style: Theme.of(context).textTheme.labelMedium,
+              ),
+              const SizedBox(width: 16),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
       );
 
   Column _paymentComponent(Payment payment) => Column(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -30,15 +30,14 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                 children: [
                   const ListTile(
                     title: Text(
-                      "Settlements",
+                      "Payments",
                     ),
                   ),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    children: widget.transaction
-                        .getSettlements()
-                        .map((e) => _settlementComponent(e))
+                    children: widget.transaction.payments
+                        .map((e) => _paymentComponent(e))
                         .toList(),
                   )
                 ],
@@ -68,14 +67,15 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                 children: [
                   const ListTile(
                     title: Text(
-                      "Payments",
+                      "Settlements",
                     ),
                   ),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    children: widget.transaction.payments
-                        .map((e) => _paymentComponent(e))
+                    children: widget.transaction
+                        .getSettlements()
+                        .map((e) => _settlementComponent(e))
                         .toList(),
                   )
                 ],
@@ -85,7 +85,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         ),
       );
 
-  Column _settlementComponent(Settlement settlement) => Column(
+  Column _paymentComponent(Payment payment) => Column(
         children: [
           const SizedBox(height: 8),
           Row(
@@ -93,24 +93,25 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             children: [
               const SizedBox(width: 48),
               Expanded(
-                flex: 2,
+                flex: 3,
                 child: Text(
-                  settlement.from.displayName,
-                  maxLines: 1,
+                  payment.title,
                   overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
                 ),
               ),
-              const Expanded(
-                child: Icon(Icons.arrow_right),
-              ),
               Expanded(
                 flex: 2,
-                child: Text(settlement.to.displayName),
+                child: Text(
+                  payment.payer.displayName,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
               ),
               Expanded(
                 flex: 2,
                 child: Text(
-                  settlement.amount.toString(),
+                  payment.price.floorAtSecondDecimal().toString(),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.end,
@@ -154,7 +155,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         ],
       );
 
-  Column _paymentComponent(Payment payment) => Column(
+  Column _settlementComponent(Settlement settlement) => Column(
         children: [
           const SizedBox(height: 8),
           Row(
@@ -162,25 +163,24 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             children: [
               const SizedBox(width: 48),
               Expanded(
-                flex: 3,
+                flex: 2,
                 child: Text(
-                  payment.title,
-                  overflow: TextOverflow.ellipsis,
+                  settlement.from.displayName,
                   maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
+              ),
+              const Expanded(
+                child: Icon(Icons.arrow_right),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(settlement.to.displayName),
               ),
               Expanded(
                 flex: 2,
                 child: Text(
-                  payment.payer.displayName,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 1,
-                ),
-              ),
-              Expanded(
-                flex: 2,
-                child: Text(
-                  payment.price.floorAtSecondDecimal().toString(),
+                  settlement.amount.toString(),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.end,

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -28,9 +28,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  const ListTile(
+                  ListTile(
                     title: Text(
                       "Payments",
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
                   ListView(
@@ -46,9 +47,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  const ListTile(
+                  ListTile(
                     title: Text(
                       "Creditors",
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
                   ListView(
@@ -65,9 +67,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  const ListTile(
+                  ListTile(
                     title: Text(
                       "Settlements",
+                      style: Theme.of(context).textTheme.titleLarge,
                     ),
                   ),
                   ListView(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -28,12 +28,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  ListTile(
-                    title: Text(
-                      "Payments",
-                      style: Theme.of(context).textTheme.titleLarge,
-                    ),
-                  ),
+                  _titleComponent("Payments"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -47,12 +42,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  ListTile(
-                    title: Text(
-                      "Creditors",
-                      style: Theme.of(context).textTheme.titleLarge,
-                    ),
-                  ),
+                  _titleComponent("Creditors"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -67,12 +57,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
             Card(
               child: Column(
                 children: [
-                  ListTile(
-                    title: Text(
-                      "Settlements",
-                      style: Theme.of(context).textTheme.titleLarge,
-                    ),
-                  ),
+                  _titleComponent("Settlements"),
                   ListView(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
@@ -85,6 +70,13 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               ),
             ),
           ],
+        ),
+      );
+
+  ListTile _titleComponent(String title) => ListTile(
+        title: Text(
+          title,
+          style: Theme.of(context).textTheme.titleLarge,
         ),
       );
 

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -194,8 +194,11 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              const Expanded(
-                child: Icon(Icons.arrow_right),
+              Expanded(
+                child: Icon(
+                  Icons.arrow_right,
+                  size: Theme.of(context).textTheme.bodyMedium?.fontSize,
+                ),
               ),
               Expanded(
                 flex: 2,


### PR DESCRIPTION
## 概要

SSIA

## 変更内容詳細

### 精算画面

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148969743-e5ee3ad2-b6c1-45f4-84bf-182e0ecba77f.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148969507-e61bba68-9dbf-4a5b-a6b5-5451c4c0c882.png">

### 立替明細入力画面

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148969697-abe915d3-6233-4bc9-be1f-f96bfb03357b.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/148969586-0733b3de-7c52-41b9-bab8-94e7d88687b1.png">
