### PR TITLE
支払い、立替、精算における小数点第2位丸め込みの扱いを徹底

### DIFF
--- a/lib/model/core/double_ext.dart
+++ b/lib/model/core/double_ext.dart
@@ -1,0 +1,4 @@
+extension DoubleExt on double {
+  double floorAtSecondDecimal() =>
+      this == 0 ? 0 : (this * 100).abs().floor() / 100 * (isNegative ? -1 : 1);
+}

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -62,7 +62,8 @@ extension PaymentsExt on List<Payment> {
 }
 
 extension DoubleExt on double {
-  double floorAtSecondDecimal() => this == 0 ? 0 : (this * 100).floor() / 100;
+  double floorAtSecondDecimal() =>
+      this == 0 ? 0 : (this * 100).abs().floor() / 100 * (isNegative ? -1 : 1);
 }
 
 extension CreditorEntriesExt on Map<Participant, double> {

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/core/no_debtors_exception.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
@@ -59,11 +60,6 @@ extension PaymentsExt on List<Payment> {
     forEach((payment) => creditorEntries.apply(payment));
     return creditorEntries;
   }
-}
-
-extension DoubleExt on double {
-  double floorAtSecondDecimal() =>
-      this == 0 ? 0 : (this * 100).abs().floor() / 100 * (isNegative ? -1 : 1);
 }
 
 extension CreditorEntriesExt on Map<Participant, double> {

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -72,8 +72,10 @@ extension CreditorEntriesExt on Map<Participant, double> {
     _addDebut(payment);
   }
 
-  void _addCredit(Payment payment) =>
-      update(payment.payer, (value) => value += payment.price);
+  void _addCredit(Payment payment) => update(
+        payment.payer,
+        (value) => (value += payment.price).floorAtSecondDecimal(),
+      );
 
   void _addDebut(Payment payment) {
     final List<Participant> debtors = payment.owners.entries
@@ -85,7 +87,7 @@ extension CreditorEntriesExt on Map<Participant, double> {
     }
     final fee = payment.price / debtors.length;
     for (final debtor in debtors) {
-      update(debtor, (value) => value -= fee);
+      update(debtor, (value) => (value -= fee).floorAtSecondDecimal());
     }
   }
 }

--- a/lib/model/entity/payment.dart
+++ b/lib/model/entity/payment.dart
@@ -1,3 +1,4 @@
+import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 
 class Payment {
@@ -9,7 +10,7 @@ class Payment {
   Payment({
     required this.title,
     required this.payer,
-    required this.price,
+    required double price,
     required this.owners,
-  });
+  }) : price = price.floorAtSecondDecimal();
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
@@ -198,8 +199,9 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         decoration: InputDecoration(hintText: paymentPriceHintValue.toString()),
         key: UniqueKey(),
         onChanged: (String value) {
-          payment.price =
-              value.isNotEmpty ? double.parse(value) : paymentPriceHintValue;
+          payment.price = value.isNotEmpty
+              ? double.parse(value).floorAtSecondDecimal()
+              : paymentPriceHintValue;
         },
         keyboardType: const TextInputType.numberWithOptions(decimal: true),
       ),

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:tatetsu/model/entity/creditor.dart';
+import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 import 'package:tatetsu/model/entity/settlement.dart';

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -166,7 +166,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               Expanded(
                 flex: 2,
                 child: Text(
-                  creditorEntry.value.floorAtSecondDecimal().toString(),
+                  creditorEntry.value.toString(),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.end,

--- a/test/model/core/double_ext.dart
+++ b/test/model/core/double_ext.dart
@@ -1,0 +1,22 @@
+import 'package:tatetsu/model/core/double_ext.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('DoubleExt', () {
+    test('DoubleExt_floorAtSecondDecimal_0の時、0', () {
+      expect(0.0.floorAtSecondDecimal(), equals(0));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる', () {
+      expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_演算の結果0.01未満と判断される負の値が切り捨てられる', () {
+      expect((-10 + 9.9900001).floorAtSecondDecimal(), equals(0));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る', () {
+      expect(28.009999999999997.floorAtSecondDecimal(), equals(28.01));
+    });
+  });
+}

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -733,9 +733,9 @@ void main() {
       expect(
         testPayments.toCreditorEntries(),
         equals({
-          testParticipant1: -9333.333333333334,
-          testParticipant2: -14883.333333333334,
-          testParticipant3: 24216.666666666664
+          testParticipant1: -9333.33,
+          testParticipant2: -14883.33,
+          testParticipant3: 24216.66
         }),
       );
     });

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -321,7 +321,7 @@ void main() {
           testParticipant2: -3.552713678800501e-15,
           testParticipant3: -1e-15,
         }),
-        true,
+        equals(true),
       );
     });
 
@@ -744,7 +744,7 @@ void main() {
       expect(0.0.floorAtSecondDecimal(), equals(0));
     });
 
-    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる、0', () {
+    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる', () {
       expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
     });
 
@@ -752,7 +752,7 @@ void main() {
       expect((-10 + 9.9900001).floorAtSecondDecimal(), equals(0));
     });
 
-    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る、0', () {
+    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る', () {
       expect(28.009999999999997.floorAtSecondDecimal(), equals(28.01));
     });
 

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -740,22 +740,6 @@ void main() {
       );
     });
 
-    test('DoubleExt_floorAtSecondDecimal_0の時、0', () {
-      expect(0.0.floorAtSecondDecimal(), equals(0));
-    });
-
-    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる', () {
-      expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
-    });
-
-    test('DoubleExt_floorAtSecondDecimal_演算の結果0.01未満と判断される負の値が切り捨てられる', () {
-      expect((-10 + 9.9900001).floorAtSecondDecimal(), equals(0));
-    });
-
-    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る', () {
-      expect(28.009999999999997.floorAtSecondDecimal(), equals(28.01));
-    });
-
     test('CreditorEntriesExt_apply_参加者1人支払者1人のPaymentを与えた時、0円の立替', () {
       final creditorEntries = {testParticipant1: 0.0};
       final testPayment = Payment(

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -263,6 +263,39 @@ void main() {
         'extractSettlement_精算対象が0.01未満の値が含まれる浮動小数点の時、誤差の含まれる精算となり、プロパティに当該の精算結果が適用される',
         () {
       final testEntries = {
+        testParticipant1: -28.00999999999997,
+        testParticipant2: 28.00999999999998,
+        testParticipant3: -0.00000000000001,
+      };
+      final testCreditor = Creditor(payments: dummyPayments)
+        ..entries = testEntries;
+
+      expect(
+        testCreditor
+            .extractSettlement(from: testParticipant1, to: testParticipant2)!
+            .isEqualTo(
+              Settlement(
+                from: testParticipant1,
+                to: testParticipant2,
+                amount: 28,
+              ),
+            ),
+        equals(true),
+      );
+      expect(
+        mapEquals(testCreditor.entries, {
+          testParticipant1: -0.009999999999969589,
+          testParticipant2: 0.009999999999980247,
+          testParticipant3: -1e-14,
+        }),
+        true,
+      );
+    });
+
+    test(
+        'extractSettlement_精算対象が0.01以上と判断される値が含まれる浮動小数点の時、切り上げた値による精算結果がプロパティに適用される',
+        () {
+      final testEntries = {
         testParticipant1: -28.009999999999997,
         testParticipant2: 28.009999999999998,
         testParticipant3: -0.000000000000001,
@@ -713,6 +746,10 @@ void main() {
 
     test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる、0', () {
       expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
+    });
+
+    test('DoubleExt_floorAtSecondDecimal_演算の結果0.01未満と判断される負の値が切り捨てられる', () {
+      expect((-10 + 9.9900001).floorAtSecondDecimal(), equals(0));
     });
 
     test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る、0', () {

--- a/test/model/entity/payment_test.dart
+++ b/test/model/entity/payment_test.dart
@@ -28,5 +28,17 @@ void main() {
         equals("modified payment"),
       );
     });
+
+    test('Payment_price属性に、0.01未満の値を含む小数値を与えた時小数点第2位で切り捨てされる', () {
+      expect(
+        Payment(
+          title: "tesutoTitle",
+          payer: Participant("tesutoPart"),
+          price: 12.341,
+          owners: {},
+        ).price,
+        equals(12.34),
+      );
+    });
   });
 }

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -158,9 +158,9 @@ void main() {
       expect(
         Transaction(testPayments).creditor.entries,
         equals({
-          testParticipant1: -9333.333333333334,
-          testParticipant2: -14883.333333333334,
-          testParticipant3: 24216.666666666664
+          testParticipant1: -9333.33,
+          testParticipant2: -14883.33,
+          testParticipant3: 24216.66
         }),
       );
     });


### PR DESCRIPTION
## 概要

誤差算出処理に向けた前準備。データ全体的に、小数点第3位以下の値が入り込まないようにした。
尚、負の値における第2位切り捨ての精度も上げている。

## 変更詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/149656347-13f6d72e-8057-4a19-a7a2-8dbcd64a6f2f.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/149656334-bffd5362-1bdb-403f-b943-af759a9c35f2.png">
