### PR TITLE
分配時、0.5以上の小数を含む支払いについての立替計算をより正確にした

### DIFF
--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -83,7 +83,7 @@ extension CreditorEntriesExt on Map<Participant, double> {
     }
     final fee = payment.price / debtors.length;
     for (final debtor in debtors) {
-      update(debtor, (value) => (value.minusAtSecondDecimal(fee)).floorAtSecondDecimal());
+      update(debtor, (value) => (value - fee).floorAtSecondDecimal());
     }
   }
 }

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -735,7 +735,7 @@ void main() {
         equals({
           testParticipant1: -9333.33,
           testParticipant2: -14883.33,
-          testParticipant3: 24216.67
+          testParticipant3: 24216.66
         }),
       );
     });

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -162,7 +162,7 @@ void main() {
         equals({
           testParticipant1: -9333.33,
           testParticipant2: -14883.33,
-          testParticipant3: 24216.67
+          testParticipant3: 24216.66
         }),
       );
     });
@@ -199,7 +199,7 @@ void main() {
         equals(true),
       );
       expect(
-        mapEquals(testSettlement.errors, {testParticipant1: 0.02}),
+        mapEquals(testSettlement.errors, {testParticipant1: 0.01}),
         equals(true),
       );
     });


### PR DESCRIPTION
## 概要

20、を3人で割った時の立替計算で、 `-6.66` と丸めた数字を引き算に使っていたため精度が下がっていた。

## 変更詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/150660363-3c391fdc-55d3-412f-9dfa-242eb4ace765.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/150660355-d9658904-7923-4498-9903-8ed13a465712.png">

## 備考

実質、 #38 での誤りの修正