### PR TITLE
立替額合計の誤差の表示機能

### DIFF
--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -49,6 +49,11 @@ class Creditor {
       ({...entries}..removeWhere((key, value) => !value.isNegative))
           .keys
           .toList();
+
+  double getError() => entries.values
+      .reduce((value, element) => value.plusAtSecondDecimal(element));
+
+  bool hasError() => getError() != 0;
 }
 
 extension PaymentsExt on List<Payment> {

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -70,7 +70,8 @@ extension CreditorEntriesExt on Map<Participant, double> {
 
   void _addCredit(Payment payment) => update(
         payment.payer,
-        (value) => (value.plusAtSecondDecimal(payment.price)).floorAtSecondDecimal(),
+        (value) =>
+            (value.plusAtSecondDecimal(payment.price)).floorAtSecondDecimal(),
       );
 
   void _addDebt(Payment payment) {

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 import 'package:tatetsu/model/entity/procedure.dart';
@@ -44,23 +45,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               ),
             ),
             Card(
-              child: Column(
-                children: [
-                  _titleComponent("Creditors"),
-                  _labelComponent("Balance"),
-                  ListView(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: widget.transaction.creditor.entries.entries
-                        .toList()
-                        .map((e) => _creditorComponent(e))
-                        .toList(),
-                  ),
-                  const SizedBox(
-                    height: 16,
-                  )
-                ],
-              ),
+              child: _creditorsComponent(widget.transaction.creditor),
             ),
             Card(
               child: _settlementComponent(widget.transaction.getSettlement()),
@@ -131,6 +116,36 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           const SizedBox(height: 8),
         ],
       );
+
+  Column _creditorsComponent(Creditor creditor) {
+    final List<Widget> baseCreditorsElements = [
+      _titleComponent("Creditors"),
+    ];
+
+    baseCreditorsElements.addAll([
+      _labelComponent("Balance"),
+      ListView(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        children: creditor.entries.entries
+            .toList()
+            .map((e) => _creditorComponent(e))
+            .toList(),
+      ),
+      const SizedBox(
+        height: 16,
+      )
+    ]);
+
+    return Column(
+      children: baseCreditorsElements
+        ..add(
+          const SizedBox(
+            height: 8,
+          ),
+        ),
+    );
+  }
 
   Column _creditorComponent(MapEntry<Participant, double> creditorEntry) =>
       Column(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -137,6 +137,16 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
       )
     ]);
 
+    if (creditor.hasError()) {
+      baseCreditorsElements.addAll([
+        _labelComponent("Error"),
+        _creditorErrorComponent(creditor.getError()),
+        const SizedBox(
+          height: 8,
+        )
+      ]);
+    }
+
     return Column(
       children: baseCreditorsElements
         ..add(
@@ -166,6 +176,36 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                 flex: 2,
                 child: Text(
                   creditorEntry.value.toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.end,
+                ),
+              ),
+              const SizedBox(width: 16),
+            ],
+          ),
+          const SizedBox(height: 8),
+        ],
+      );
+
+  Column _creditorErrorComponent(double errorAmount) => Column(
+        children: [
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const SizedBox(width: 16),
+              const Expanded(
+                flex: 5,
+                child: Text(
+                  "Total",
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Expanded(
+                flex: 2,
+                child: Text(
+                  errorAmount.toString(),
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   textAlign: TextAlign.end,

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -489,6 +489,86 @@ void main() {
       });
     });
 
+    test('getError_立替が0件の時、エラー', () {
+      expect(
+        () => (Creditor(payments: dummyPayments)..entries = {}).getError(),
+        throwsStateError,
+      );
+    });
+
+    test('getError_立替が1件の時、当該の値と等しい値', () {
+      expect(
+        (Creditor(payments: dummyPayments)..entries = {testParticipant1: 10})
+            .getError(),
+        equals(10),
+      );
+    });
+
+    test('getError_立替が2件以上で、合計値が0より大きくなる時、その合計値', () {
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 10,
+                testParticipant2: 200,
+                testParticipant3: 3000
+              })
+            .getError(),
+        equals(3210),
+      );
+    });
+
+    test('getError_立替が2件以上で、正確な合計値が0にはならないが小数点2桁以下無視した合計値が0になる時、0', () {
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 10,
+                testParticipant2: -10.00999999999999,
+              })
+            .getError(),
+        equals(0),
+      );
+    });
+
+    test('hasError_合計値が0より大きい立替の時、true', () {
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 13.33,
+                testParticipant2: -6.66,
+                testParticipant3: -6.66
+              })
+            .hasError(),
+        equals(true),
+      );
+    });
+
+    test('hasError_合計値が0の立替の時、false', () {
+      // 浮動小数点の誤差に依存するテストケースは呼び出し先で担保とする
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 20,
+                testParticipant2: -10,
+                testParticipant3: -10
+              })
+            .hasError(),
+        equals(false),
+      );
+    });
+
+    test('hasError_合計値が0未満の立替の時、true', () {
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 6.66,
+                testParticipant2: 6.66,
+                testParticipant3: -13.33
+              })
+            .hasError(),
+        equals(true),
+      );
+    });
+
     test('PaymentsExt_toCreditorEntries_Paymentが空の時、エラー', () {
       final List<Payment> testPayments = [];
 


### PR DESCRIPTION
## 概要

割り切れない数が出てきた時の違和感への対応。
割り切れない数が出てこない時は表示しない。

## 変更内容詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/150662907-589d5795-8b5b-4fc4-b0ea-555315ca7cb5.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/150662894-686feb97-6215-4a64-804c-6a6c28e7709e.png">
