### PR TITLE
精算結果共有機能

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     android.ndkVersion "21.4.7075529"
 
     sourceSets {
@@ -41,7 +41,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.ntetz.flutter.tatetsu"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -54,6 +54,11 @@ class Creditor {
       .reduce((value, element) => value.plusAtSecondDecimal(element));
 
   bool hasError() => getError() != 0;
+
+  String toSummary() => [
+    "[Creditors]",
+    ...entries.entries.map((e) => "${e.key.displayName}: ${e.value}")
+  ].join("\n");
 }
 
 extension PaymentsExt on List<Payment> {

--- a/lib/model/entity/settlement.dart
+++ b/lib/model/entity/settlement.dart
@@ -6,4 +6,11 @@ class Settlement {
   Map<Participant, double> errors;
 
   Settlement({required this.procedures, required this.errors});
+
+  String toSummary() => [
+        "[Settlement]",
+        ...procedures.map(
+          (e) => "${e.from.displayName} -> ${e.to.displayName}: ${e.amount}",
+        )
+      ].join("\n");
 }

--- a/lib/model/entity/summary_message.dart
+++ b/lib/model/entity/summary_message.dart
@@ -1,0 +1,6 @@
+class SummaryMessage {
+  String title;
+  String body;
+
+  SummaryMessage({required this.title, required this.body});
+}

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -55,11 +55,13 @@ extension ProceduresExt on List<Procedure> {
     for (final procedure in this) {
       settlementBaseCreditor.entries.update(
         procedure.from,
-        (value) => value.plusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
+        (value) =>
+            value.plusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
       );
       settlementBaseCreditor.entries.update(
         procedure.to,
-        (value) => value.minusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
+        (value) =>
+            value.minusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
       );
     }
 

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -5,6 +5,7 @@ import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 import 'package:tatetsu/model/entity/procedure.dart';
 import 'package:tatetsu/model/entity/settlement.dart';
+import 'package:tatetsu/model/entity/summary_message.dart';
 
 class Transaction {
   List<Payment> payments;
@@ -14,10 +15,26 @@ class Transaction {
   Transaction(this.payments)
       : creditor = payments.toCreditor(),
         settlement = payments.toCreditor().toSettlement();
+
+  SummaryMessage toSummaryMessage() => SummaryMessage(
+        title: "Settlements on 1/29/2022 15:45",
+        body: [
+          payments.toSummary(),
+          creditor.toSummary(),
+          settlement.toSummary()
+        ].join("\n\n"),
+      );
 }
 
 extension PaymentsExt on List<Payment> {
   Creditor toCreditor() => Creditor(payments: this);
+
+  String toSummary() => [
+        "[Payments]",
+        ...map(
+          (e) => "${e.title}(${e.payer.displayName}): ${e.price.toString()}",
+        ),
+      ].join("\n");
 }
 
 extension CreditorExt on Creditor {

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -1,4 +1,5 @@
 import 'package:collection/collection.dart';
+import 'package:intl/intl.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
@@ -16,8 +17,9 @@ class Transaction {
       : creditor = payments.toCreditor(),
         settlement = payments.toCreditor().toSettlement();
 
-  SummaryMessage toSummaryMessage() => SummaryMessage(
-        title: "Settlements on 1/29/2022 15:45",
+  SummaryMessage toSummaryMessage({DateTime? datetime}) => SummaryMessage(
+        title:
+            "Settlements on ${DateFormat.yMd().add_Hm().format(datetime ?? DateTime.now())}",
         body: [
           payments.toSummary(),
           creditor.toSummary(),

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -7,20 +7,27 @@ import 'package:tatetsu/model/entity/procedure.dart';
 import 'package:tatetsu/model/entity/settlement.dart';
 
 class Transaction {
-  Creditor creditor;
   List<Payment> payments;
+  Creditor creditor;
+  Settlement settlement;
 
-  Transaction(this.payments) : creditor = Creditor(payments: payments);
+  Transaction(this.payments)
+      : creditor = payments.toCreditor(),
+        settlement = payments.toCreditor().toSettlement();
+}
 
-  Settlement getSettlement() {
-    final procedures = creditor.getSettlementProcedures();
-    final errors = procedures.getSettlementErrors(toward: creditor);
-
-    return Settlement(procedures: procedures, errors: errors);
-  }
+extension PaymentsExt on List<Payment> {
+  Creditor toCreditor() => Creditor(payments: this);
 }
 
 extension CreditorExt on Creditor {
+  Settlement toSettlement() {
+    final procedures = getSettlementProcedures();
+    final errors = procedures.getSettlementErrors(toward: this);
+
+    return Settlement(procedures: procedures, errors: errors);
+  }
+
   List<Procedure> getSettlementProcedures() {
     final settlementBaseCreditor = Creditor(payments: payments);
     return getDebtors()

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -22,13 +22,13 @@ extension PaymentsExt on List<Payment> {
 
 extension CreditorExt on Creditor {
   Settlement toSettlement() {
-    final procedures = getSettlementProcedures();
+    final procedures = _getSettlementProcedures();
     final errors = procedures.getSettlementErrors(toward: this);
 
     return Settlement(procedures: procedures, errors: errors);
   }
 
-  List<Procedure> getSettlementProcedures() {
+  List<Procedure> _getSettlementProcedures() {
     final settlementBaseCreditor = Creditor(payments: payments);
     return getDebtors()
         .map(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
@@ -28,7 +29,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               style: TextButton.styleFrom(
                 primary: Theme.of(context).colorScheme.onPrimary,
               ),
-              onPressed: () {},
+              onPressed: () {
+                final summaryMessage = widget.transaction.toSummaryMessage();
+                Share.share(summaryMessage.body, subject: summaryMessage.title);
+              },
               child: const Icon(
                 Icons.share,
                 size: 32,

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -23,6 +23,18 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
           title: const Text("Credit Summaries"),
+          actions: [
+            TextButton(
+              style: TextButton.styleFrom(
+                primary: Theme.of(context).colorScheme.onPrimary,
+              ),
+              onPressed: () {},
+              child: const Icon(
+                Icons.share,
+                size: 32,
+              ),
+            )
+          ],
         ),
         body: ListView(
           children: [

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -60,7 +60,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               child: _creditorsComponent(widget.transaction.creditor),
             ),
             Card(
-              child: _settlementComponent(widget.transaction.getSettlement()),
+              child: _settlementComponent(widget.transaction.settlement),
             ),
           ],
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -158,6 +158,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.0"
   io:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -130,6 +130,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -242,6 +247,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
   pool:
     dependency: transitive
     description:
@@ -256,6 +268,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.4"
+  share_plus_linux:
+    dependency: transitive
+    description:
+      name: share_plus_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  share_plus_macos:
+    dependency: transitive
+    description:
+      name: share_plus_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  share_plus_web:
+    dependency: transitive
+    description:
+      name: share_plus_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  share_plus_windows:
+    dependency: transitive
+    description:
+      name: share_plus_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   shelf:
     dependency: transitive
     description:
@@ -366,6 +420,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: transitive
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.18"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.14"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.6"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   vector_math:
     dependency: transitive
     description:
@@ -410,3 +520,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.15.0 <3.0.0"
+  flutter: ">=2.5.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
+  share_plus: ^3.0.4
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   english_words: ^4.0.0
   flutter:
     sdk: flutter
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -569,6 +569,69 @@ void main() {
       );
     });
 
+    test('toSummary_立替0件の時、ラベルのみを返す', () {
+      final List<Payment> dummyPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+          },
+        )
+      ];
+
+      expect(
+        (Creditor(payments: dummyPayments)..entries = {}).toSummary(),
+        equals("[Creditors]"),
+      );
+    });
+
+    test('toSummary_立替1件の時、ラベルに加えて対象者と金額を改行1つで繋げて返す', () {
+      final List<Payment> dummyPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+          },
+        )
+      ];
+
+      expect(
+        (Creditor(payments: dummyPayments)..entries = {testParticipant1: 30})
+            .toSummary(),
+        equals("[Creditors]\ntestName1: 30.0"),
+      );
+    });
+
+    test('toSummary_立替2件以上の時、全ての立替が含まれた値を改行1つで繋げて返す', () {
+      final List<Payment> dummyPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+          },
+        )
+      ];
+
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 30,
+                testParticipant2: -100,
+                testParticipant3: 4000
+              })
+            .toSummary(),
+        equals(
+          "[Creditors]\ntestName1: 30.0\ntestName2: -100.0\ntestName3: 4000.0",
+        ),
+      );
+    });
+
     test('PaymentsExt_toCreditorEntries_Paymentが空の時、エラー', () {
       final List<Payment> testPayments = [];
 

--- a/test/model/entity/settlement_test.dart
+++ b/test/model/entity/settlement_test.dart
@@ -1,0 +1,37 @@
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/procedure.dart';
+import 'package:tatetsu/model/entity/settlement.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final Participant testParticipant1 = Participant("testName1");
+  final Participant testParticipant2 = Participant("testName2");
+  final Participant testParticipant3 = Participant("testName3");
+
+  group('Settlement', () {
+    test('Settlement_procedures属性に、プロパティを外部から操作しなかった時引数で渡した値が設定される', () {
+      final testProcedures = [
+        Procedure(from: testParticipant1, to: testParticipant2, amount: 30),
+        Procedure(from: testParticipant2, to: testParticipant3, amount: 400),
+      ];
+
+      expect(
+        Settlement(procedures: testProcedures, errors: {}).procedures,
+        equals(testProcedures),
+      );
+    });
+
+    test('Settlement_procedures属性に、プロパティを外部から操作した時書き換え後の値が設定される', () {
+      final testProcedures = [
+        Procedure(from: testParticipant1, to: testParticipant2, amount: 30),
+        Procedure(from: testParticipant2, to: testParticipant3, amount: 400),
+      ];
+
+      expect(
+        (Settlement(procedures: testProcedures, errors: {})..procedures = [])
+            .procedures,
+        equals([]),
+      );
+    });
+  });
+}

--- a/test/model/entity/settlement_test.dart
+++ b/test/model/entity/settlement_test.dart
@@ -7,6 +7,7 @@ void main() {
   final Participant testParticipant1 = Participant("testName1");
   final Participant testParticipant2 = Participant("testName2");
   final Participant testParticipant3 = Participant("testName3");
+  final Participant testParticipant4 = Participant("testName4");
 
   group('Settlement', () {
     test('Settlement_procedures属性に、プロパティを外部から操作しなかった時引数で渡した値が設定される', () {
@@ -31,6 +32,51 @@ void main() {
         (Settlement(procedures: testProcedures, errors: {})..procedures = [])
             .procedures,
         equals([]),
+      );
+    });
+
+    test('toSummary_procedures属性に空配列を渡した時、ラベルのみを返す', () {
+      expect(
+        Settlement(procedures: [], errors: {}).toSummary(),
+        equals("[Settlement]"),
+      );
+    });
+
+    test('toSummary_procedures属性に1件を渡した時、ラベルに加えて支払元、支払先と支払量を改行1つで繋げて返す', () {
+      expect(
+        Settlement(
+          procedures: [
+            Procedure(from: testParticipant1, to: testParticipant2, amount: 30),
+          ],
+          errors: {},
+        ).toSummary(),
+        equals(
+          "[Settlement]\ntestName1 -> testName2: 30.0",
+        ),
+      );
+    });
+
+    test('toSummary_procedures属性に2件以上を渡した時、全ての手続きが含まれた値を改行1つで繋げて返す', () {
+      expect(
+        Settlement(
+          procedures: [
+            Procedure(from: testParticipant1, to: testParticipant2, amount: 30),
+            Procedure(
+              from: testParticipant2,
+              to: testParticipant3,
+              amount: 400,
+            ),
+            Procedure(
+              from: testParticipant4,
+              to: testParticipant1,
+              amount: 5000,
+            ),
+          ],
+          errors: {},
+        ).toSummary(),
+        equals(
+          "[Settlement]\ntestName1 -> testName2: 30.0\ntestName2 -> testName3: 400.0\ntestName4 -> testName1: 5000.0",
+        ),
       );
     });
   });

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -167,7 +167,7 @@ void main() {
       );
     });
 
-    test('getSettlement_与えたPaymentの精算結果に誤差が発生する際、手順及び精算結果誤差が含まれる', () {
+    test('PaymentsExt_toCreditor_与えたPaymentに基づいた立替を返す', () {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -180,7 +180,27 @@ void main() {
           },
         )
       ];
-      final testSettlement = Transaction(testPayments).getSettlement();
+      expect(
+        testPayments.toCreditor().payments,
+        equals(testPayments),
+      );
+    });
+
+    test('CreditorExt_toSettlement_与えたPaymentの精算結果に誤差が発生する際、手順及び精算結果誤差が含まれる',
+        () {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 20,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true,
+          },
+        )
+      ];
+      final testSettlement = Creditor(payments: testPayments).toSettlement();
       expect(
         testSettlement.procedures.hasEquivalentElements(
           to: [

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -174,6 +174,51 @@ void main() {
       );
     });
 
+    test('toSummaryMessage_title属性がSettlements on から始まる文字列である', () {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      expect(
+        Transaction(testPayments)
+            .toSummaryMessage()
+            .title
+            .startsWith("Settlements on "),
+        equals(true),
+      );
+    });
+
+    test('toSummaryMessage_title属性がyMd Hm形式の文字列である', () {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      expect(
+        Transaction(testPayments)
+            .toSummaryMessage(datetime: DateTime(2000, 1, 23, 16, 56))
+            .title,
+        equals("Settlements on 1/23/2000 16:56"),
+      );
+    });
+
     test(
         'toSummaryMessage_1件のPaymentを与えている時、body属性が支払、立替、精算の順に改行2つで繋がったメッセージを返す',
         () {

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -22,6 +22,13 @@ void main() {
   };
 
   group('Transaction', () {
+    test('Transaction_与える支払いが空の時、エラー', () {
+      expect(
+        () => Transaction([]),
+        throwsStateError,
+      );
+    });
+
     test('Transaction_creditor属性が、Paymentが1つの時立替額が均等割される', () {
       final List<Payment> testPayments = [
         Payment(

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -224,7 +224,7 @@ void main() {
       );
     });
 
-    test('CreditorExt_getSettlementProcedures_立替費0の参加者１人の時、空配列', () {
+    test('CreditorExt_toSettlement_立替費0の参加者１人の時、手順が空配列', () {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -237,13 +237,13 @@ void main() {
       ];
 
       expect(
-        Creditor(payments: testPayments).getSettlementProcedures(),
+        Creditor(payments: testPayments).toSettlement().procedures,
         equals([]),
       );
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_プラス立替費者者1人とマイナス立替費者者1人の時、マイナス立替者からプラス立替者への精算1つ',
+        'CreditorExt_toSettlement_プラス立替費者者1人とマイナス立替費者者1人の時、手順がマイナス立替者からプラス立替者への精算1つ',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -259,7 +259,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -274,7 +275,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_プラス立替費者者4人とマイナス立替費者者1人の時、マイナス立替者からプラス立替者への精算4つ',
+        'CreditorExt_toSettlement_プラス立替費者者4人とマイナス立替費者者1人の時、手順がマイナス立替者からプラス立替者への精算4つ',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -311,7 +312,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -341,7 +343,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の小さなプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、マイナス立替者2人からの精算2件ずつ',
+        'CreditorExt_toSettlement_差の小さなプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順がマイナス立替者2人からの精算2件ずつ',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -378,7 +380,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -408,7 +411,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の小さなプラス立替費者者3人と差の大きなマイナス立替費者者2人(早順番者がマイナス大)の時、早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
+        'CreditorExt_toSettlement_差の小さなプラス立替費者者3人と差の大きなマイナス立替費者者2人(早順番者がマイナス大)の時、手順が早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -445,7 +448,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -475,7 +479,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の小さなプラス立替費者者3人と差の大きなマイナス立替費者者2人(早順番者がマイナス小)の時、早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
+        'CreditorExt_toSettlement_差の小さなプラス立替費者者3人と差の大きなマイナス立替費者者2人(早順番者がマイナス小)の時、手順が早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -512,7 +516,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -542,7 +547,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(早順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
+        'CreditorExt_toSettlement_1人(早順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -579,7 +584,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -609,7 +615,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(中順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_1人(中順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -646,7 +652,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -676,7 +683,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(遅順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
+        'CreditorExt_toSettlement_1人(遅順番者)が特に大きいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -713,7 +720,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -743,7 +751,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(早順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_1人(早順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -780,7 +788,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -810,7 +819,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(中順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_1人(中順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -847,7 +856,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -877,7 +887,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_1人(遅順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_1人(遅順番者)が特に小さいプラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -914,7 +924,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -944,7 +955,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(早<中<遅)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
+        'CreditorExt_toSettlement_差の大きな(早<中<遅)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -981,7 +992,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -1011,7 +1023,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(早<遅<中)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_差の大きな(早<遅<中)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1048,7 +1060,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -1078,7 +1091,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(中<早<遅)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
+        'CreditorExt_toSettlement_差の大きな(中<早<遅)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算3件と遅順番マイナス立替者からの精算1件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1115,7 +1128,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -1145,7 +1159,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(中<遅<早)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
+        'CreditorExt_toSettlement_差の大きな(中<遅<早)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1182,7 +1196,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -1212,7 +1227,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(遅<早<中)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
+        'CreditorExt_toSettlement_差の大きな(遅<早<中)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算2件と遅順番マイナス立替者からの精算2件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1249,7 +1264,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(
@@ -1279,7 +1295,7 @@ void main() {
     });
 
     test(
-        'CreditorExt_getSettlementProcedures_差の大きな(遅<中<早)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
+        'CreditorExt_toSettlement_差の大きな(遅<中<早)プラス立替費者者3人と差の小さなマイナス立替費者者2人の時、手順が早順番マイナス立替者からの精算1件と遅順番マイナス立替者からの精算3件',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1316,7 +1332,8 @@ void main() {
 
       expect(
         Creditor(payments: testPayments)
-            .getSettlementProcedures()
+            .toSettlement()
+            .procedures
             .hasEquivalentElements(
           to: [
             Procedure(

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -174,6 +174,100 @@ void main() {
       );
     });
 
+    test(
+        'toSummaryMessage_1件のPaymentを与えている時、body属性が支払、立替、精算の順に改行2つで繋がったメッセージを返す',
+        () {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      expect(
+        Transaction(testPayments).toSummaryMessage().body,
+        equals(
+          [
+            '[Payments]\n',
+            'testPaymentA(testName1): 6000.0',
+            '\n\n',
+            '[Creditors]\n',
+            'testName1: 4000.0\n',
+            'testName2: -2000.0\n',
+            'testName3: -2000.0',
+            '\n\n',
+            '[Settlement]\n',
+            'testName2 -> testName1: 2000.0\n',
+            'testName3 -> testName1: 2000.0'
+          ].join(),
+        ),
+      );
+    });
+
+    test(
+        'toSummaryMessage_2件以上のPaymentを与えている時、body属性が支払、立替、精算の順に改行2つで繋がったメッセージを返す',
+        () {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+        Payment(
+          title: "testPaymentB",
+          payer: testParticipant2,
+          price: 900,
+          owners: {
+            testParticipant1: false,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+        Payment(
+          title: "testPaymentC",
+          payer: testParticipant3,
+          price: 30000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        )
+      ];
+
+      expect(
+        Transaction(testPayments).toSummaryMessage().body,
+        equals(
+          [
+            '[Payments]\n',
+            'testPaymentA(testName1): 6000.0\n',
+            'testPaymentB(testName2): 900.0\n',
+            'testPaymentC(testName3): 30000.0',
+            '\n\n',
+            '[Creditors]\n',
+            'testName1: -6000.0\n',
+            'testName2: -11550.0\n',
+            'testName3: 17550.0',
+            '\n\n',
+            '[Settlement]\n',
+            'testName1 -> testName3: 6000.0\n',
+            'testName2 -> testName3: 11550.0'
+          ].join(),
+        ),
+      );
+    });
+
     test('PaymentsExt_toCreditor_与えたPaymentに基づいた立替を返す', () {
       final List<Payment> testPayments = [
         Payment(
@@ -190,6 +284,71 @@ void main() {
       expect(
         testPayments.toCreditor().payments,
         equals(testPayments),
+      );
+    });
+
+    test('PaymentsExt_toSummary_空配列を与えた時、ラベルのみを返す', () {
+      expect(
+        <Payment>[].toSummary(),
+        equals("[Payments]"),
+      );
+    });
+
+    test('PaymentsExt_toSummary_1件の支払いを与えた時、ラベルに加えて支払名と支払者と金額を改行1つで繋げて返す', () {
+      expect(
+        [
+          Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 20,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true,
+            },
+          )
+        ].toSummary(),
+        equals("[Payments]\ntestPaymentA(testName1): 20.0"),
+      );
+    });
+
+    test('PaymentsExt_toSummary_2件以上の支払いを与えた時、全ての支払いが含まれた値を改行1つで繋げて返す', () {
+      expect(
+        [
+          Payment(
+            title: "testPaymentA",
+            payer: testParticipant1,
+            price: 20,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true,
+            },
+          ),
+          Payment(
+            title: "testPaymentB",
+            payer: testParticipant2,
+            price: 300,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true,
+            },
+          ),
+          Payment(
+            title: "testPaymentC",
+            payer: testParticipant3,
+            price: 4000,
+            owners: {
+              testParticipant1: true,
+              testParticipant2: true,
+              testParticipant3: true,
+            },
+          )
+        ].toSummary(),
+        equals(
+          "[Payments]\ntestPaymentA(testName1): 20.0\ntestPaymentB(testName2): 300.0\ntestPaymentC(testName3): 4000.0",
+        ),
       );
     });
 


### PR DESCRIPTION
## 概要

精算結果をメールなりLINEなりで共有するための機能の追加

## 変更詳細

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/151652265-5ac05444-4265-4e11-ad54-0040307f3bbd.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/151652236-04063ce1-be59-41dc-860f-20ee9eaa4c13.png">


## 参考

下記が参考になった

### 共有

https://plus.fluttercommunity.dev/docs/share_plus/usage
https://pub.dev/packages/share_plus
https://qiita.com/shimopata/items/142b39bab6176b6a5da9

### 日付

https://api.flutter.dev/flutter/intl/DateFormat-class.html
https://pub.dev/packages/intl/install

### メソッドデフォルト値

https://dart.dev/tools/diagnostic-messages?utm_source=dartdev&utm_medium=redir&utm_id=diagcode&utm_content=non_constant_default_value#non_constant_default_value