### PR TITLE
入力域に入力する内容をより想像しやすくした

### DIFF
--- a/lib/ui/core/string_ext.dart
+++ b/lib/ui/core/string_ext.dart
@@ -1,0 +1,3 @@
+extension StringExt on String {
+  String toHintText() => "e.g. $this";
+}

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
@@ -131,13 +132,13 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   ListTile _paymentHeader(PaymentComponent payment) {
-    final String paymentTitleHint = payment.title;
+    final String defaultPaymentTitle = payment.title;
     return ListTile(
       title: TextFormField(
-        decoration: InputDecoration(hintText: paymentTitleHint),
+        decoration: InputDecoration(hintText: defaultPaymentTitle.toHintText()),
         key: UniqueKey(),
         onChanged: (String value) {
-          payment.title = value.isNotEmpty ? value : paymentTitleHint;
+          payment.title = value.isNotEmpty ? value : defaultPaymentTitle;
         },
       ),
     );
@@ -191,17 +192,19 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   List<Widget> _priceView(PaymentComponent payment) {
-    final double paymentPriceHintValue = payment.price;
+    final double defaultPaymentPriceValue = payment.price;
     return [
       const SizedBox(height: 16),
       Text("Price", style: Theme.of(context).textTheme.labelMedium),
       TextFormField(
-        decoration: InputDecoration(hintText: paymentPriceHintValue.toString()),
+        decoration: InputDecoration(
+          hintText: defaultPaymentPriceValue.toString().toHintText(),
+        ),
         key: UniqueKey(),
         onChanged: (String value) {
           payment.price = value.isNotEmpty
               ? double.parse(value).floorAtSecondDecimal()
-              : paymentPriceHintValue;
+              : defaultPaymentPriceValue;
         },
         keyboardType: const TextInputType.numberWithOptions(decimal: true),
       ),

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -8,7 +8,9 @@ import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
   InputAccountingDetailPage({required this.participants})
-      : payments = [PaymentComponent(participants: participants)],
+      : payments = [
+          PaymentComponent(participants: participants)..price = 66
+        ],
         super();
 
   final List<Participant> participants;

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -5,7 +5,7 @@ import 'package:tatetsu/model/entity/payment.dart';
 class PaymentComponent {
   bool isExpanded = true;
 
-  String title = "Some Payment";
+  String title = "Lunch at the nice cafe";
   Participant payer;
   double price = 0.0;
   Map<Participant, bool> owners;

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
+import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
 
 class InputParticipantsPage extends StatefulWidget {
@@ -86,19 +87,20 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
 
   Row _createParticipantInputArea(int participantIndex) {
     final bool hasOnlyParticipants = _participants.length <= 1;
-    final String participantNameHint =
+    final String defaultParticipantName =
         _participants[participantIndex].displayName;
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Expanded(
           child: TextFormField(
-            decoration: InputDecoration(hintText: participantNameHint),
+            decoration:
+                InputDecoration(hintText: defaultParticipantName.toHintText()),
             key: UniqueKey(),
             onChanged: (String value) {
               // テキストエリアに表示されている値を引き継ぎたい
               _participants[participantIndex].displayName =
-                  value.isNotEmpty ? value : participantNameHint;
+                  value.isNotEmpty ? value : defaultParticipantName;
             },
           ),
         ),

--- a/test/ui/core/string_ext_test.dart
+++ b/test/ui/core/string_ext_test.dart
@@ -1,0 +1,11 @@
+import 'package:tatetsu/ui/core/string_ext.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('StringExt_toHintText_元の値に対して、例示であることがわかる接頭辞が付与された値を返す', () {
+    expect(
+      'testname1'.toHintText(),
+      'e.g. testname1',
+    );
+  });
+}

--- a/test/ui/input_accounting_detail/payment_component_test.dart
+++ b/test/ui/input_accounting_detail/payment_component_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('PaymentComponent_title属性に、クラス内で指定したデフォルト値が設定される', () {
       expect(
         PaymentComponent(participants: [Participant("testName")]).title,
-        equals("Some Payment"),
+        equals("Lunch at the nice cafe"),
       );
     });
 
@@ -39,7 +39,7 @@ void main() {
         PaymentComponent(participants: [testParticipant1, testParticipant2])
             .toPayment()
             .title,
-        equals("Some Payment"),
+        equals("Lunch at the nice cafe"),
       );
     });
 
@@ -59,7 +59,7 @@ void main() {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..title = "Some Payment"
+            ..title = "Lunch at the nice cafe"
             ..payer = testParticipant1
             ..price = 0.0
             ..owners = {testParticipant1: true, testParticipant2: true}


### PR DESCRIPTION
## 概要

接頭辞の追加と、ダミーデータの見直し

## 変更詳細

### 参加者入力画面

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152630134-4c5be3e7-8b03-472d-b21f-9cba59e47f1c.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152630112-ad621bf1-d1a0-4da2-8885-c02b1cf50323.png">

### 会計明細入力画面

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152630131-584e7fd5-197f-4a2e-957f-708f227303f1.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152630123-c07f76ce-ab98-4d7c-b99b-59854cf42981.png">

## 参考

海外圏でのHintテキスト例

https://sso.tennistv.com/auth/realms/TennisTV/protocol/openid-connect/registrations?client_id=tennis-tv-web&redirect_uri=https%3A%2F%2Fwww.tennistv.com%2Fsubscribe&state=b2661bc8-eb8b-44a6-8c30-ee85074f2756&response_mode=fragment&response_type=code&scope=openid&nonce=315f0657-829b-4368-8680-055459a906f4&ui_locales=en

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/38374045/152630148-ea370ed5-541a-46c5-b0ae-3a03e905ae12.png">
