### PR TITLE
会計明細入力画面で、未編集なのに編集内容棄却確認ダイアログが出てしまう不具合を修正

### DIFF
--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -8,9 +8,7 @@ import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
   InputAccountingDetailPage({required this.participants})
-      : payments = [
-          PaymentComponent(participants: participants)..price = 66
-        ],
+      : payments = [PaymentComponent.sample(participants: participants)],
         super();
 
   final List<Participant> participants;
@@ -85,7 +83,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   Future<bool> _showDiscardConfirmDialogIfNeeded() => widget.payments
-          .hasOnlyDefaultElements(onParticipants: widget.participants)
+          .hasOnlySampleElement(onParticipants: widget.participants)
       ? Future(() => true)
       : showDialog<bool>(
           context: context,

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -5,7 +5,7 @@ import 'package:tatetsu/model/entity/payment.dart';
 class PaymentComponent {
   bool isExpanded = true;
 
-  String title = "Lunch at the nice cafe";
+  String title = "Some Payment";
   Participant payer;
   double price = 0.0;
   Map<Participant, bool> owners;
@@ -14,19 +14,25 @@ class PaymentComponent {
       : payer = participants.first,
         owners = Map.fromIterables(participants, participants.map((_) => true));
 
+  PaymentComponent.sample({required List<Participant> participants})
+      : title = "Lunch at the nice cafe",
+        payer = participants.first,
+        price = 66,
+        owners = Map.fromIterables(participants, participants.map((_) => true));
+
   Payment toPayment() =>
       Payment(title: title, payer: payer, price: price, owners: owners);
 }
 
 extension PaymentComponentsExt on List<PaymentComponent> {
-  bool hasOnlyDefaultElements({required List<Participant> onParticipants}) {
+  bool hasOnlySampleElement({required List<Participant> onParticipants}) {
     if (length != 1) {
       return false;
     }
-    final defaultElement = PaymentComponent(participants: onParticipants);
-    return first.title == defaultElement.title &&
-        first.payer == defaultElement.payer &&
-        first.price == defaultElement.price &&
-        mapEquals(first.owners, defaultElement.owners);
+    final sampleElement = PaymentComponent.sample(participants: onParticipants);
+    return first.title == sampleElement.title &&
+        first.payer == sampleElement.payer &&
+        first.price == sampleElement.price &&
+        mapEquals(first.owners, sampleElement.owners);
   }
 }

--- a/test/ui/input_accounting_detail/payment_component_test.dart
+++ b/test/ui/input_accounting_detail/payment_component_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('PaymentComponent_title属性に、クラス内で指定したデフォルト値が設定される', () {
       expect(
         PaymentComponent(participants: [Participant("testName")]).title,
-        equals("Lunch at the nice cafe"),
+        equals("Some Payment"),
       );
     });
 
@@ -34,12 +34,22 @@ void main() {
       );
     });
 
+    test('PaymentComponent_sample_owners属性に、title属性に、ユーザーが想像しやすいような名前が設定される',
+        () {
+      expect(
+        PaymentComponent.sample(
+          participants: [testParticipant1, testParticipant2],
+        ).title,
+        equals("Lunch at the nice cafe"),
+      );
+    });
+
     test('toPayment_プロパティを外部から操作しなかった時、クラス内で指定したデフォルト値を含むPaymentオブジェクトを返す', () {
       expect(
         PaymentComponent(participants: [testParticipant1, testParticipant2])
             .toPayment()
             .title,
-        equals("Lunch at the nice cafe"),
+        equals("Some Payment"),
       );
     });
 
@@ -53,90 +63,86 @@ void main() {
       );
     });
 
-    test(
-        'PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つでプロパティがデフォルトと同じ時true',
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つでプロパティがサンプルと同じ時true',
         () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
             ..title = "Lunch at the nice cafe"
             ..payer = testParticipant1
-            ..price = 0.0
+            ..price = 66.0
             ..owners = {testParticipant1: true, testParticipant2: true}
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         true,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで支払名が異なる時false',
-        () {
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払名が異なる時false', () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
             ..title = "modified title"
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで支払者が異なる時false',
-        () {
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払者が異なる時false', () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
             ..payer = testParticipant2
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで価格が異なる時false', () {
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで価格が異なる時false', () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
             ..price = 0.01
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つで精算対象者が異なる時false',
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで精算対象者が異なる時false',
         () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
             ..owners = {testParticipant1: true, testParticipant2: false}
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が1つだが参加者が異なる時false',
-        () {
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つだが参加者が異なる時false', () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2])
-        ].hasOnlyDefaultElements(onParticipants: [testParticipant1]),
+        ].hasOnlySampleElement(onParticipants: [testParticipant1]),
         false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlyDefaultElements_要素数が2以上の時false', () {
+    test('PaymentComponentsExt_hasOnlySampleElement_要素数が2以上の時false', () {
       expect(
         [
           PaymentComponent(participants: [testParticipant1, testParticipant2]),
           PaymentComponent(participants: [testParticipant1, testParticipant2])
-        ].hasOnlyDefaultElements(
+        ].hasOnlySampleElement(
           onParticipants: [testParticipant1, testParticipant2],
         ),
         false,


### PR DESCRIPTION
## 概要

#50 の考慮もれ。
また、それに伴い、サンプル生成処理をviewから引き剥がすリファクタリングを行なっている。

