### PR TITLE
本番系ビルドにおいて、テーマカラーにアプリアイコンと同じ値が設定されるようにした

### DIFF
--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -11,10 +11,26 @@ class Tatetsu extends StatelessWidget {
     return MaterialApp(
       title: 'Tatetsu',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        primarySwatch: _tatetsuViolet,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
       home: const InputParticipantsPage(title: 'Participants'),
     );
   }
+
+  static const MaterialColor _tatetsuViolet = MaterialColor(
+    0xFF8489B6,
+    {
+      50: Color(0xFFF0F1F6),
+      100: Color(0xFFDADCE9),
+      200: Color(0xFFC2C4DB),
+      300: Color(0xFFA9ACCC),
+      400: Color(0xFF969BC1),
+      500: Color(0xFF8489B6),
+      600: Color(0xFF7C81AF),
+      700: Color(0xFF7176A6),
+      800: Color(0xFF676C9E),
+      900: Color(0xFF54598E),
+    },
+  );
 }


### PR DESCRIPTION
## 概要

アイコンと同じ色にした。

## 変更詳細

### Android

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152679877-3be88e14-c52a-47e6-81b0-dafb46f9527c.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/152679415-b5ac5705-b340-4a98-b9f0-164fd55661e7.png">

### iOS

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/152679829-8c885722-0e4a-43c4-97e9-de615a409cdb.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/152679760-898ecd53-3138-440c-99a2-5e97f1e35451.png">

## 参考

利用している色は、配色アイデア手帖の `朝焼けの富士 - Early Morning`。カラーコードは `#8489b6`

https://www.sbcr.jp/product/4797393248/