### PR TITLE
Crashlytics追加

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,12 +6,19 @@ PODS:
     - FirebaseAnalytics (~> 8.11.0)
   - Firebase/CoreOnly (8.11.0):
     - FirebaseCore (= 8.11.0)
+  - Firebase/Crashlytics (8.11.0):
+    - Firebase/CoreOnly
+    - FirebaseCrashlytics (~> 8.11.0)
   - firebase_analytics (9.1.0):
     - Firebase/Analytics (= 8.11.0)
     - firebase_core
     - Flutter
   - firebase_core (1.12.0):
     - Firebase/CoreOnly (= 8.11.0)
+    - Flutter
+  - firebase_crashlytics (2.5.1):
+    - Firebase/Crashlytics (= 8.11.0)
+    - firebase_core
     - Flutter
   - FirebaseAnalytics (8.11.0):
     - FirebaseAnalytics/AdIdSupport (= 8.11.0)
@@ -40,6 +47,13 @@ PODS:
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
+  - FirebaseCrashlytics (8.11.0):
+    - FirebaseCore (~> 8.0)
+    - FirebaseInstallations (~> 8.0)
+    - GoogleDataTransport (~> 9.1)
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (~> 2.30908.0)
+    - PromisesObjC (< 3.0, >= 1.2)
   - FirebaseInstallations (8.12.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
@@ -103,6 +117,7 @@ PODS:
 DEPENDENCIES:
   - firebase_analytics (from `.symlinks/plugins/firebase_analytics/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
+  - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -113,6 +128,7 @@ SPEC REPOS:
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreDiagnostics
+    - FirebaseCrashlytics
     - FirebaseInstallations
     - GoogleAppMeasurement
     - GoogleDataTransport
@@ -125,6 +141,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_analytics/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
+  firebase_crashlytics:
+    :path: ".symlinks/plugins/firebase_crashlytics/ios"
   Flutter:
     :path: Flutter
   share_plus:
@@ -136,9 +154,11 @@ SPEC CHECKSUMS:
   Firebase: 44dd9724c84df18b486639e874f31436eaa9a20c
   firebase_analytics: b267e923ba3cdc892bdcadc01efab50f3b8b7441
   firebase_core: 443bccfd6aa6b42f07be365b500773dc69db2d87
+  firebase_crashlytics: 0df152ee2d96f5a4aeddf2288fb277bbd0833b18
   FirebaseAnalytics: 4e4b13031034e6561ed3bd1d47b6fdabbd6487c6
   FirebaseCore: 2f4f85b453cc8fea4bb2b37e370007d2bcafe3f0
   FirebaseCoreDiagnostics: 3b40dfadef5b90433a60ae01f01e90fe87aa76aa
+  FirebaseCrashlytics: 62268addefae79601057818156e8bc69d71fee41
   FirebaseInstallations: 25764cf322e77f99449395870a65b2bef88e1545
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   GoogleAppMeasurement: aa3cb422fab2b05d2efac543a5720d1a85b9dea5

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				3BD02E801AF5F1046A06E900 /* [CP] Embed Pods Frameworks */,
+				671067F827B6346200312934 /* Upload Crashlytics dSYM */,
 			);
 			buildRules = (
 			);
@@ -280,6 +281,24 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		671067F827B6346200312934 /* Upload Crashlytics dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Crashlytics dSYM";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$PODS_ROOT/FirebaseCrashlytics/run\n";
 		};
 		67950AD227B5F9B900263B03 /* Set Firebase Config */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,6 +169,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.4"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.1"
+  firebase_crashlytics_platform_interface:
+    dependency: transitive
+    description:
+      name: firebase_crashlytics_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.13"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   english_words: ^4.0.0
   firebase_analytics: ^9.1.0
   firebase_core: ^1.12.0
+  firebase_crashlytics: ^2.5.1
   flutter:
     sdk: flutter
   intl: ^0.17.0


### PR DESCRIPTION
## 概要

SSIA

## 動作確認

公式通り、下記を仕込んだデモアプリにて動作確認。

```dart
FirebaseCrashlytics.instance.crash();
```

### Android

dev|prd
---|---
<img width="1155" alt="image" src="https://user-images.githubusercontent.com/38374045/153567212-d47b3d91-9016-4b6c-99d7-d2d5338c9cee.png">|<img width="1155" alt="image" src="https://user-images.githubusercontent.com/38374045/153567184-4b3b688f-1cf7-4b80-8a1f-ffaecc7bddd3.png">

### iOS

dev|prd
---|---
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/38374045/153567277-a694e92d-0a9c-4890-bc3b-2cfe2d06d0bb.png">|<img width="1152" alt="image" src="https://user-images.githubusercontent.com/38374045/153567317-18a7f395-3222-4c57-babc-ab1f9b94a9e7.png">

## 参考

### 公式(このままやっても、iOSがいい感じに飛ばなかった)

https://pub.dev/packages/firebase_crashlytics
https://firebase.flutter.dev/docs/crashlytics/overview
https://firebase.google.com/docs/crashlytics/get-started?hl=ja&platform=ios

### iOSのクラッシュが表示されない問題

https://github.com/FirebaseExtended/flutterfire/issues/1951

### iOSのクラッシュを表示するためのdSYM送信

https://firebase.google.com/docs/crashlytics/get-deobfuscated-reports?platform=ios&authuser=0
https://firebase.google.com/docs/crashlytics/get-started?hl=ja&platform=ios#set-up-dsym-uploading