### PR TITLE
AdMob導入を見据えた、環境ごとの設定値を切り替えやすい機構の導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ app.*.map.json
 # fastlane
 **/report.xml
 
+# configs
+lib/config/dev.dart
+lib/config/prd.dart
+
 # flutter_launcher_icons
 android/app/src/*/res/*/ic_launcher.png
 ios/Runner/Assets.xcassets/AppIcon-*.appiconset/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,16 @@ stages:
     displayName: 静的解析
     steps:
     - task: DownloadSecureFile@1
+      displayName: 'Download dev Flavor config file'
+      name: FlavorDevSettings
+      inputs:
+        secureFile: dev.dart
+    - task: DownloadSecureFile@1
+      displayName: 'Download prd Flavor config file'
+      name: FlavorPrdSettings
+      inputs:
+        secureFile: prd.dart
+    - task: DownloadSecureFile@1
       displayName: 'Download Android dev Firebase config file'
       name: FirebaseAndroidDevSettings
       inputs:
@@ -38,6 +48,14 @@ stages:
       name: FirebaseIosPrdSettings
       inputs:
         secureFile: tatetsu-GoogleService-Info-prd.plist
+    - script: |
+        echo '>> sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart'
+        sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart
+      displayName: 'Set dev Flavor config file reference'
+    - script: |
+        echo '>> sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart'
+        sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart
+      displayName: 'Set prd Flavor config file reference'
     - script: |
         echo '>> sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json'
         sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json
@@ -86,6 +104,16 @@ stages:
     displayName: Firebaseへベータ版アプリ配布
     steps:
     - task: DownloadSecureFile@1
+      displayName: 'Download dev Flavor config file'
+      name: FlavorDevSettings
+      inputs:
+        secureFile: dev.dart
+    - task: DownloadSecureFile@1
+      displayName: 'Download prd Flavor config file'
+      name: FlavorPrdSettings
+      inputs:
+        secureFile: prd.dart
+    - task: DownloadSecureFile@1
       displayName: 'Download Android dev Firebase config file'
       name: FirebaseAndroidDevSettings
       inputs:
@@ -105,6 +133,14 @@ stages:
       name: FirebaseIosPrdSettings
       inputs:
         secureFile: tatetsu-GoogleService-Info-prd.plist
+    - script: |
+        echo '>> sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart'
+        sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart
+      displayName: 'Set dev Flavor config file reference'
+    - script: |
+        echo '>> sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart'
+        sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart
+      displayName: 'Set prd Flavor config file reference'
     - script: |
         echo '>> sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json'
         sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json

--- a/lib/config/application_meta.dart
+++ b/lib/config/application_meta.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_flavor/flutter_flavor.dart';
 import 'package:tatetsu/config/core.dart';
@@ -26,5 +28,18 @@ String getEntryPageTitle() {
     return FlavorConfig.instance.variables["entry_page_title"] as String;
   } catch (e) {
     return "Participants";
+  }
+}
+
+String getSettleAccountsTopBannerId() {
+  try {
+    return (Platform.isAndroid || Platform.isFuchsia)
+        ? FlavorConfig.instance
+            .variables["settle_accounts_top_banner_id_android"] as String
+        : FlavorConfig.instance.variables["settle_accounts_top_banner_id_ios"]
+            as String;
+  } catch (e) {
+    // テスト広告のID https://developers.google.com/admob/ios/test-ads#demo_ad_units
+    return "ca-app-pub-3940256099942544/2934735716";
   }
 }

--- a/lib/config/application_meta.dart
+++ b/lib/config/application_meta.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_flavor/flutter_flavor.dart';
+import 'package:tatetsu/config/core.dart';
+
+String getAppTitle() {
+  try {
+    return FlavorConfig.instance.variables["application_title"] as String;
+  } catch (e) {
+    return "Tatetsu";
+  }
+}
+
+ThemeData getAppTheme() {
+  try {
+    return FlavorConfig.instance.variables["application_theme"] as ThemeData;
+  } catch (e) {
+    return ThemeData(
+      primarySwatch: tatetsuViolet,
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+    );
+  }
+}
+
+String getEntryPageTitle() {
+  try {
+    return FlavorConfig.instance.variables["entry_page_title"] as String;
+  } catch (e) {
+    return "Participants";
+  }
+}

--- a/lib/config/core.dart
+++ b/lib/config/core.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+const MaterialColor tatetsuViolet = MaterialColor(
+  0xFF8489B6,
+  {
+    50: Color(0xFFF0F1F6),
+    100: Color(0xFFDADCE9),
+    200: Color(0xFFC2C4DB),
+    300: Color(0xFFA9ACCC),
+    400: Color(0xFF969BC1),
+    500: Color(0xFF8489B6),
+    600: Color(0xFF7C81AF),
+    700: Color(0xFF7176A6),
+    800: Color(0xFF676C9E),
+    900: Color(0xFF54598E),
+  },
+);

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_flavor/flutter_flavor.dart';
+
+void setConfig() => FlavorConfig(
+      name: "name",
+      variables: {
+        "application_title": "title",
+        "application_theme": ThemeData(
+          primarySwatch: Colors.red,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+        ),
+        "entry_page_title": "title"
+      },
+    );

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -9,6 +9,10 @@ void setConfig() => FlavorConfig(
           primarySwatch: Colors.red,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
-        "entry_page_title": "title"
+        "entry_page_title": "title",
+        "settle_accounts_top_banner_id_ios":
+            "ca-app-pub-3940256099942544/2934735716",
+        "settle_accounts_top_banner_id_android":
+            "ca-app-pub-3940256099942544/2934735716"
       },
     );

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,20 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/config/application_meta.dart';
+import 'package:tatetsu/config/dev.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
+  setConfig();
   runApp(Tatetsu());
 }
 
 class Tatetsu extends StatelessWidget {
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Tatetsu Dev',
-      theme: ThemeData(
-        primarySwatch: Colors.red,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
-      home: const InputParticipantsPage(title: '[Dev] Participants'),
-    );
-  }
+  Widget build(BuildContext context) => MaterialApp(
+        title: getAppTitle(),
+        theme: getAppTheme(),
+        home: InputParticipantsPage(
+          title: getEntryPageTitle(),
+        ),
+      );
 }

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -1,36 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/config/application_meta.dart';
+import 'package:tatetsu/config/prd.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
+  setConfig();
   runApp(Tatetsu());
 }
 
 class Tatetsu extends StatelessWidget {
   @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Tatetsu',
-      theme: ThemeData(
-        primarySwatch: _tatetsuViolet,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
-      home: const InputParticipantsPage(title: 'Participants'),
-    );
-  }
-
-  static const MaterialColor _tatetsuViolet = MaterialColor(
-    0xFF8489B6,
-    {
-      50: Color(0xFFF0F1F6),
-      100: Color(0xFFDADCE9),
-      200: Color(0xFFC2C4DB),
-      300: Color(0xFFA9ACCC),
-      400: Color(0xFF969BC1),
-      500: Color(0xFF8489B6),
-      600: Color(0xFF7C81AF),
-      700: Color(0xFF7176A6),
-      800: Color(0xFF676C9E),
-      900: Color(0xFF54598E),
-    },
-  );
+  Widget build(BuildContext context) => MaterialApp(
+        title: getAppTitle(),
+        theme: getAppTheme(),
+        home: InputParticipantsPage(
+          title: getEntryPageTitle(),
+        ),
+      );
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -188,6 +188,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_flavor:
+    dependency: "direct main"
+    description:
+      name: flutter_flavor
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.3"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   firebase_crashlytics: ^2.5.1
   flutter:
     sdk: flutter
+  flutter_flavor: ^3.0.3
   intl: ^0.17.0
   share_plus: ^3.0.4
 

--- a/test/config/application_meta_test.dart
+++ b/test/config/application_meta_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:tatetsu/config/application_meta.dart';
+import 'package:tatetsu/config/core.dart';
+import 'package:tatetsu/config/dev.dart' as dev;
+import 'package:tatetsu/config/prd.dart' as prd;
+import 'package:test/test.dart';
+
+void main() {
+  group('ApplicationMeta', () {
+    test('getAppTitle_devのsetConfig実施後に実行した時、devの接尾辞のついたタイトルを返す', () {
+      dev.setConfig();
+      expect(getAppTitle(), equals("Tatetsu Dev"));
+    });
+
+    test('getAppTitle_prdのsetConfig実施後に実行した時、接尾辞のないタイトルを返す', () {
+      prd.setConfig();
+      expect(getAppTitle(), equals("Tatetsu"));
+    });
+
+    test('getAppTheme_devのsetConfig実施後に実行した時、色が赤のテーマを返す', () {
+      dev.setConfig();
+      expect(getAppTheme().primaryColor, Colors.red);
+    });
+
+    test('getAppTheme_prdのsetConfig実施後に実行した時、色がメインカラーのテーマを返す', () {
+      prd.setConfig();
+      expect(getAppTheme().primaryColor, tatetsuViolet);
+    });
+
+    test('getEntryPageTitle_devのsetConfig実施後に実行した時、devの接頭辞のついたページ名を返す', () {
+      dev.setConfig();
+      expect(getEntryPageTitle(), equals("[Dev] Participants"));
+    });
+
+    test('getEntryPageTitle_prdのsetConfig実施後に実行した時、接頭辞のないページ名を返す', () {
+      prd.setConfig();
+      expect(getEntryPageTitle(), equals("Participants"));
+    });
+
+    test('getSettleAccountsTopBannerId_devのsetConfig実施後に実行した時、AdMobのテスト広告IDを返す', () {
+      dev.setConfig();
+      expect(getSettleAccountsTopBannerId(), equals("ca-app-pub-3940256099942544/2934735716"));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

AdMobで、アプリのIDや広告のユニットIDを自在に変更したいため、実行条件に応じて読み込み先を変えられる仕組みを追加。
AdMob導入まで入れると変更量が大きくなるので、PRとしてはリファクタリングにとどめる

## 参考

下記が参考になった。

### flavor

https://pub.dev/packages/flutter_flavor

### platform判別

https://stackoverflow.com/questions/45924474/how-do-you-detect-the-host-platform-from-dart-code