### PR TITLE
精算画面に、AdMobによる広告が表示されるようにした

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ ios/Runner/Assets.xcassets/AppIcon-*.appiconset/
 # Firebase
 android/app/src/*/google-services.json
 ios/Firebase/GoogleService-Info-*.plist
+
+# Android Secret Build Config
+android/gradle_secret.properties

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ ios/Firebase/GoogleService-Info-*.plist
 
 # Android Secret Build Config
 android/gradle_secret.properties
+
+# AdMob for iOS
+ios/AdMob/AdMob-dev.xcconfig
+ios/AdMob/AdMob-prd.xcconfig

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.ntetz.flutter.tatetsu"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -6,6 +6,10 @@ if (localPropertiesFile.exists()) {
     }
 }
 
+def keyPropertiesFile = rootProject.file("gradle_secret.properties")
+def keyProperties = new Properties()
+keyProperties.load(new FileInputStream(keyPropertiesFile))
+
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
     throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
@@ -61,10 +65,12 @@ android {
             dimension "apiEnv"
             applicationIdSuffix ".dev"
             resValue "string", "app_name", "T-dev"
+            resValue "string", "admob_app_id", keyProperties["admobDevAppId"]
         }
         prd {
             dimension "apiEnv"
             resValue "string", "app_name", "tatetsu"
+            resValue "string", "admob_app_id", keyProperties["admobPrdAppId"]
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,5 +39,8 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="@string/admob_app_id"/>
     </application>
 </manifest>

--- a/android/gradle_secret_sample.properties
+++ b/android/gradle_secret_sample.properties
@@ -1,0 +1,2 @@
+admobDevAppId=ca-app-pub-xxxxxxxxxxxxxxxx~xxxxxxxxxx
+admobPrdAppId=ca-app-pub-xxxxxxxxxxxxxxxx~xxxxxxxxxx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,11 @@ stages:
       inputs:
         secureFile: prd.dart
     - task: DownloadSecureFile@1
+      displayName: 'Download Android build config file'
+      name: AndroidBuildSettings
+      inputs:
+        secureFile: gradle_secret.properties
+    - task: DownloadSecureFile@1
       displayName: 'Download Android dev Firebase config file'
       name: FirebaseAndroidDevSettings
       inputs:
@@ -44,10 +49,20 @@ stages:
       inputs:
         secureFile: tatetsu-GoogleService-Info-dev.plist
     - task: DownloadSecureFile@1
+      displayName: 'Download iOS dev AdMob config file'
+      name: AdmobIosDevSettings
+      inputs:
+        secureFile: AdMob-dev.xcconfig
+    - task: DownloadSecureFile@1
       displayName: 'Download iOS prd Firebase config file'
       name: FirebaseIosPrdSettings
       inputs:
         secureFile: tatetsu-GoogleService-Info-prd.plist
+    - task: DownloadSecureFile@1
+      displayName: 'Download iOS prd AdMob config file'
+      name: AdmobIosPrdSettings
+      inputs:
+        secureFile: AdMob-prd.xcconfig
     - script: |
         echo '>> sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart'
         sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart
@@ -56,6 +71,10 @@ stages:
         echo '>> sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart'
         sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart
       displayName: 'Set prd Flavor config file reference'
+    - script: |
+        echo '>> sudo ln -s $(AndroidBuildSettings.secureFilePath) android/gradle_secret.properties'
+        sudo ln -s $(AndroidBuildSettings.secureFilePath) android/gradle_secret.properties
+      displayName: 'Set Android build config file reference'
     - script: |
         echo '>> sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json'
         sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json
@@ -69,9 +88,17 @@ stages:
         sudo ln -s $(FirebaseIosDevSettings.secureFilePath) ios/Firebase/GoogleService-Info-dev.plist
       displayName: 'Set iOS dev Firebase config file reference'
     - script: |
+        echo '>> sudo ln -s $(AdmobIosDevSettings.secureFilePath) ios/AdMob/AdMob-dev.xcconfig'
+        sudo ln -s $(AdmobIosDevSettings.secureFilePath) ios/AdMob/AdMob-dev.xcconfig
+      displayName: 'Set iOS dev AdMob config file reference'
+    - script: |
         echo '>> sudo ln -s $(FirebaseIosPrdSettings.secureFilePath) ios/Firebase/GoogleService-Info-prd.plist'
         sudo ln -s $(FirebaseIosPrdSettings.secureFilePath) ios/Firebase/GoogleService-Info-prd.plist
       displayName: 'Set iOS prd Firebase config file reference'
+    - script: |
+        echo '>> sudo ln -s $(AdmobIosPrdSettings.secureFilePath) ios/AdMob/AdMob-prd.xcconfig'
+        sudo ln -s $(AdmobIosPrdSettings.secureFilePath) ios/AdMob/AdMob-prd.xcconfig
+      displayName: 'Set iOS prd AdMob config file reference'
     - task: JavaToolInstaller@0
       inputs:
         versionSpec: '11'
@@ -114,6 +141,11 @@ stages:
       inputs:
         secureFile: prd.dart
     - task: DownloadSecureFile@1
+      displayName: 'Download Android build config file'
+      name: AndroidBuildSettings
+      inputs:
+        secureFile: gradle_secret.properties
+    - task: DownloadSecureFile@1
       displayName: 'Download Android dev Firebase config file'
       name: FirebaseAndroidDevSettings
       inputs:
@@ -129,10 +161,20 @@ stages:
       inputs:
         secureFile: tatetsu-GoogleService-Info-dev.plist
     - task: DownloadSecureFile@1
+      displayName: 'Download iOS dev AdMob config file'
+      name: AdmobIosDevSettings
+      inputs:
+        secureFile: AdMob-dev.xcconfig
+    - task: DownloadSecureFile@1
       displayName: 'Download iOS prd Firebase config file'
       name: FirebaseIosPrdSettings
       inputs:
         secureFile: tatetsu-GoogleService-Info-prd.plist
+    - task: DownloadSecureFile@1
+      displayName: 'Download iOS prd AdMob config file'
+      name: AdmobIosPrdSettings
+      inputs:
+        secureFile: AdMob-prd.xcconfig
     - script: |
         echo '>> sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart'
         sudo ln -s $(FlavorDevSettings.secureFilePath) lib/config/dev.dart
@@ -141,6 +183,10 @@ stages:
         echo '>> sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart'
         sudo ln -s $(FlavorPrdSettings.secureFilePath) lib/config/prd.dart
       displayName: 'Set prd Flavor config file reference'
+    - script: |
+        echo '>> sudo ln -s $(AndroidBuildSettings.secureFilePath) android/gradle_secret.properties'
+        sudo ln -s $(AndroidBuildSettings.secureFilePath) android/gradle_secret.properties
+      displayName: 'Set Android build config file reference'
     - script: |
         echo '>> sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json'
         sudo ln -s $(FirebaseAndroidDevSettings.secureFilePath) android/app/src/dev/google-services.json
@@ -154,9 +200,17 @@ stages:
         sudo ln -s $(FirebaseIosDevSettings.secureFilePath) ios/Firebase/GoogleService-Info-dev.plist
       displayName: 'Set iOS dev Firebase config file reference'
     - script: |
+        echo '>> sudo ln -s $(AdmobIosDevSettings.secureFilePath) ios/AdMob/AdMob-dev.xcconfig'
+        sudo ln -s $(AdmobIosDevSettings.secureFilePath) ios/AdMob/AdMob-dev.xcconfig
+      displayName: 'Set iOS dev AdMob config file reference'
+    - script: |
         echo '>> sudo ln -s $(FirebaseIosPrdSettings.secureFilePath) ios/Firebase/GoogleService-Info-prd.plist'
         sudo ln -s $(FirebaseIosPrdSettings.secureFilePath) ios/Firebase/GoogleService-Info-prd.plist
       displayName: 'Set iOS prd Firebase config file reference'
+    - script: |
+        echo '>> sudo ln -s $(AdmobIosPrdSettings.secureFilePath) ios/AdMob/AdMob-prd.xcconfig'
+        sudo ln -s $(AdmobIosPrdSettings.secureFilePath) ios/AdMob/AdMob-prd.xcconfig
+      displayName: 'Set iOS prd AdMob config file reference'
     - task: JavaToolInstaller@0
       inputs:
         versionSpec: '11'

--- a/ios/AdMob/AdMob-sample.xcconfig
+++ b/ios/AdMob/AdMob-sample.xcconfig
@@ -1,0 +1,11 @@
+//
+//  AdMob-sample.xcconfig
+//  Runner
+//
+//  Created by Tetsuya Nishikawa on 2/12/22.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+ADMOB_APP_ID=ca-app-pub-xxxxxxxxxxxxxxxx~xxxxxxxxxx

--- a/ios/Flutter/DebugDev.xcconfig
+++ b/ios/Flutter/DebugDev.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"
 
+#include "AdMob/AdMob-dev.xcconfig"
+
 APP_NAME=T-DebDev
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-dev

--- a/ios/Flutter/DebugPrd.xcconfig
+++ b/ios/Flutter/DebugPrd.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-prd.xcconfig"
 
+#include "AdMob/AdMob-prd.xcconfig"
+
 APP_NAME=T-DebPrd
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-prd

--- a/ios/Flutter/ProfileDev.xcconfig
+++ b/ios/Flutter/ProfileDev.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"
 
+#include "AdMob/AdMob-dev.xcconfig"
+
 APP_NAME=T-ProDev
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-dev

--- a/ios/Flutter/ProfilePrd.xcconfig
+++ b/ios/Flutter/ProfilePrd.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-prd.xcconfig"
 
+#include "AdMob/AdMob-prd.xcconfig"
+
 APP_NAME=T-ProPrd
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-prd

--- a/ios/Flutter/ReleaseDev.xcconfig
+++ b/ios/Flutter/ReleaseDev.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"
 
+#include "AdMob/AdMob-dev.xcconfig"
+
 APP_NAME=T-RelDev
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-dev

--- a/ios/Flutter/ReleasePrd.xcconfig
+++ b/ios/Flutter/ReleasePrd.xcconfig
@@ -11,5 +11,7 @@
 #include "Generated.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release-prd.xcconfig"
 
+#include "AdMob/AdMob-prd.xcconfig"
+
 APP_NAME=tatetsu
 ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-prd

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -60,6 +60,12 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
   - Flutter (1.0.0)
+  - Google-Mobile-Ads-SDK (8.11.0):
+    - GoogleAppMeasurement (< 9.0, >= 7.0)
+    - GoogleUserMessagingPlatform (>= 1.1)
+  - google_mobile_ads (0.0.1):
+    - Flutter
+    - Google-Mobile-Ads-SDK (= 8.11.0)
   - GoogleAppMeasurement (8.11.0):
     - GoogleAppMeasurement/AdIdSupport (= 8.11.0)
     - GoogleUtilities/AppDelegateSwizzler (~> 7.7)
@@ -84,6 +90,7 @@ PODS:
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUserMessagingPlatform (2.0.0)
   - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -119,6 +126,7 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - Flutter (from `Flutter`)
+  - google_mobile_ads (from `.symlinks/plugins/google_mobile_ads/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
@@ -130,8 +138,10 @@ SPEC REPOS:
     - FirebaseCoreDiagnostics
     - FirebaseCrashlytics
     - FirebaseInstallations
+    - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
     - GoogleDataTransport
+    - GoogleUserMessagingPlatform
     - GoogleUtilities
     - nanopb
     - PromisesObjC
@@ -145,6 +155,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_crashlytics/ios"
   Flutter:
     :path: Flutter
+  google_mobile_ads:
+    :path: ".symlinks/plugins/google_mobile_ads/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   url_launcher_ios:
@@ -161,8 +173,11 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 62268addefae79601057818156e8bc69d71fee41
   FirebaseInstallations: 25764cf322e77f99449395870a65b2bef88e1545
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Google-Mobile-Ads-SDK: be2192b51b74d74a6ed70590c2e8275412f1b71e
+  google_mobile_ads: a2f8b901601401bf7e691b4224d5992e9a37599a
   GoogleAppMeasurement: aa3cb422fab2b05d2efac543a5720d1a85b9dea5
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
+  GoogleUserMessagingPlatform: ab890ce5f6620f293a21b6bdd82e416a2c73aeca
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -46,6 +46,9 @@
 		675F0B3726AA755A005AC815 /* ReleasePrd.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = ReleasePrd.xcconfig; path = Flutter/ReleasePrd.xcconfig; sourceTree = "<group>"; };
 		67950ACE27B5F91100263B03 /* GoogleService-Info-dev.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-dev.plist"; sourceTree = "<group>"; };
 		67950ACF27B5F91100263B03 /* GoogleService-Info-prd.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-prd.plist"; sourceTree = "<group>"; };
+		67AAB01A27B76A5000922E54 /* AdMob-dev.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "AdMob-dev.xcconfig"; sourceTree = "<group>"; };
+		67AAB01B27B76A6100922E54 /* AdMob-prd.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "AdMob-prd.xcconfig"; sourceTree = "<group>"; };
+		67AAB01C27B76A8900922E54 /* AdMob-sample.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "AdMob-sample.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		80EA267CC7F20FA8C5D106F8 /* Pods-Runner.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release-dev.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"; sourceTree = "<group>"; };
@@ -81,6 +84,16 @@
 			path = Firebase;
 			sourceTree = "<group>";
 		};
+		67C2EA5427B69CEC00BC87F9 /* AdMob */ = {
+			isa = PBXGroup;
+			children = (
+				67AAB01A27B76A5000922E54 /* AdMob-dev.xcconfig */,
+				67AAB01B27B76A6100922E54 /* AdMob-prd.xcconfig */,
+				67AAB01C27B76A8900922E54 /* AdMob-sample.xcconfig */,
+			);
+			path = AdMob;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +115,7 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				67950ACD27B5F8F600263B03 /* Firebase */,
+				67C2EA5427B69CEC00BC87F9 /* AdMob */,
 				97C146EF1CF9000F007C117D /* Products */,
 				ECC9B3F4D30FE1CD7538707D /* Pods */,
 				D807BD38E2B3111EAD6D8D87 /* Frameworks */,

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -41,5 +41,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>GADApplicationIdentifier</key>
+	<string>$(ADMOB_APP_ID)</string>
 </dict>
 </plist>

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/dev.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
   setConfig();
+  WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
+  MobileAds.instance.initialize();
   runApp(Tatetsu());
 }
 

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/prd.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
   setConfig();
+  WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
+  MobileAds.instance.initialize();
   runApp(Tatetsu());
 }
 

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -1,0 +1,11 @@
+import 'package:google_mobile_ads/google_mobile_ads.dart';
+import 'package:tatetsu/config/application_meta.dart';
+
+class AdvertisementUsecase {
+  BannerAd getSettleAccountsTopBanner() => BannerAd(
+        size: AdSize.banner,
+        adUnitId: getSettleAccountsTopBannerId(),
+        listener: const BannerAdListener(),
+        request: const AdRequest(),
+      )..load();
+}

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
@@ -6,6 +7,7 @@ import 'package:tatetsu/model/entity/payment.dart';
 import 'package:tatetsu/model/entity/procedure.dart';
 import 'package:tatetsu/model/entity/settlement.dart';
 import 'package:tatetsu/model/entity/transaction.dart';
+import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 
 class SettleAccountsPage extends StatefulWidget {
   SettleAccountsPage({required this.payments})
@@ -42,6 +44,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         ),
         body: ListView(
           children: [
+            Card(
+              child: _adTopBannerComponent(),
+            ),
             Card(
               child: Column(
                 children: [
@@ -93,6 +98,20 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           const SizedBox(height: 8),
         ],
       );
+
+  Column _adTopBannerComponent() {
+    final banner = AdvertisementUsecase().getSettleAccountsTopBanner();
+    return Column(
+      children: [
+        Container(
+          alignment: Alignment.center,
+          width: banner.size.width.toDouble(),
+          height: banner.size.height.toDouble(),
+          child: AdWidget(ad: banner),
+        )
+      ],
+    );
+  }
 
   Column _paymentComponent(Payment payment) => Column(
         children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -226,6 +226,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  google_mobile_ads:
+    dependency: "direct main"
+    description:
+      name: google_mobile_ads
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_flavor: ^3.0.3
+  google_mobile_ads: ^1.1.0
   intl: ^0.17.0
   share_plus: ^3.0.4
 

--- a/test/model/usecase/advertisement_usecase_test.dart
+++ b/test/model/usecase/advertisement_usecase_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/config/dev.dart' as dev;
+import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
+
+void main() {
+  group('AdvertisementUsecase', () {
+    test(
+        'getSettleAccountsTopBanner_devのsetConfigとWidgetsFlutterBindingの初期化実施後に実行した時、IDがテスト用の広告を返す',
+        () {
+      dev.setConfig();
+      TestWidgetsFlutterBinding.ensureInitialized();
+      expect(
+        AdvertisementUsecase().getSettleAccountsTopBanner().adUnitId,
+        equals("ca-app-pub-3940256099942544/2934735716"),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

公式に従ってAdMobを導入。
Google AdMob側にアプリを追加する作業も別途行っている。

## 変更内容詳細

### Android

変更前|変更後
---|---
<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/153697867-ca1f9e02-f596-4062-9df0-0a023ee1c2cf.png">|<img width="444" alt="image" src="https://user-images.githubusercontent.com/38374045/153697811-3c2648f7-3ecb-4716-98a5-75bd82e23f0f.png">

### iOS

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153698028-f3d9be54-570a-432b-ae43-c042c34a289d.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153697757-9084b5bb-b58a-4623-9374-0811b59e9ddf.png">

## TODO

- 広告の詳細諸々
  - デザインとインタラクション
  - dispose()の実装
  - 表示時にAndroidで握りつぶされているように見えるエラー `java.lang.NoClassDefFoundError: Failed resolution of: Landroid/content/pm/PackageManager$OnChecksumsReadyListener`

## 参考

### Flutter

https://pub.dev/packages/google_mobile_ads/install

### 公式

https://firebase.google.com/docs/admob/ios/quick-start?authuser=0
https://developers.google.com/admob/flutter/quick-start
https://developers.google.com/admob/flutter/banner
https://developers.google.com/admob/ios/test-ads#demo_ad_units

### AdMob動作向けのiOSのビルド用に必要だったxcconfig読み込み

https://archive.craftz.dog/blog.odoruinu.net/2014/01/07/xcconfigを複数ファイル構成にする方法/index.html

### AdMob追加によるAndroidのビルドエラー対応

https://developer.android.com/studio/build/multidex?hl=ja