### PR TITLE
広告読込高速化

### DIFF
--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/dev.dart';
+import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
-  MobileAds.instance.initialize();
+  AdvertisementUsecase.shared().initialize();
   runApp(Tatetsu());
 }
 

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/prd.dart';
+import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 void main() {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
-  MobileAds.instance.initialize();
+  AdvertisementUsecase.shared().initialize();
   runApp(Tatetsu());
 }
 

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -15,5 +15,14 @@ class AdvertisementUsecase {
           adUnitId: getSettleAccountsTopBannerId(),
           listener: const BannerAdListener(),
           request: const AdRequest(),
-        )..load();
+        );
+
+  void initialize() {
+    MobileAds.instance.initialize();
+    _loadAllAdBanner();
+  }
+
+  void _loadAllAdBanner() {
+    settleAccountsTopBanner.load();
+  }
 }

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -2,10 +2,18 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 
 class AdvertisementUsecase {
-  BannerAd getSettleAccountsTopBanner() => BannerAd(
-        size: AdSize.banner,
-        adUnitId: getSettleAccountsTopBannerId(),
-        listener: const BannerAdListener(),
-        request: const AdRequest(),
-      )..load();
+  static final AdvertisementUsecase _singleton =
+      AdvertisementUsecase._internal();
+
+  factory AdvertisementUsecase.shared() => _singleton;
+
+  BannerAd settleAccountsTopBanner;
+
+  AdvertisementUsecase._internal()
+      : settleAccountsTopBanner = BannerAd(
+          size: AdSize.banner,
+          adUnitId: getSettleAccountsTopBannerId(),
+          listener: const BannerAdListener(),
+          request: const AdRequest(),
+        )..load();
 }

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -25,4 +25,7 @@ class AdvertisementUsecase {
   void _loadAllAdBanner() {
     settleAccountsTopBanner.load();
   }
+
+  bool isSettleAccountsTopBannerSuccessfullyLoaded() =>
+      settleAccountsTopBanner.responseInfo != null;
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
@@ -113,6 +114,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         builder: (BuildContext context) {
           return SettleAccountsPage(
             payments: widget.payments.map((e) => e.toPayment()).toList(),
+            advertisementUsecase: AdvertisementUsecase.shared(),
           );
         },
       ),

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -46,37 +46,41 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
           ],
         ),
         body: ListView(
-          children: [
-            Card(
-              child: _adTopBannerComponent(widget.advertisementUsecase),
-            ),
-            Card(
-              child: Column(
-                children: [
-                  _titleComponent("Payments"),
-                  _labelComponent("Items"),
-                  ListView(
-                    shrinkWrap: true,
-                    physics: const NeverScrollableScrollPhysics(),
-                    children: widget.transaction.payments
-                        .map((e) => _paymentComponent(e))
-                        .toList(),
-                  ),
-                  const SizedBox(
-                    height: 16,
-                  )
-                ],
-              ),
-            ),
-            Card(
-              child: _creditorsComponent(widget.transaction.creditor),
-            ),
-            Card(
-              child: _settlementComponent(widget.transaction.settlement),
-            ),
-          ],
+          children: _settleAccountsComponents(this),
         ),
       );
+
+  List<Card> _settleAccountsComponents(State<SettleAccountsPage> state) {
+    return [
+      Card(
+        child: _adTopBannerComponent(state.widget.advertisementUsecase),
+      ),
+      Card(
+        child: Column(
+          children: [
+            _titleComponent("Payments"),
+            _labelComponent("Items"),
+            ListView(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              children: state.widget.transaction.payments
+                  .map((e) => _paymentComponent(e))
+                  .toList(),
+            ),
+            const SizedBox(
+              height: 16,
+            )
+          ],
+        ),
+      ),
+      Card(
+        child: _creditorsComponent(state.widget.transaction.creditor),
+      ),
+      Card(
+        child: _settlementComponent(state.widget.transaction.settlement),
+      ),
+    ];
+  }
 
   ListTile _titleComponent(String title) => ListTile(
         title: Text(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -10,12 +10,15 @@ import 'package:tatetsu/model/entity/transaction.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 
 class SettleAccountsPage extends StatefulWidget {
-  SettleAccountsPage({required this.payments})
-      : transaction = Transaction(payments),
+  SettleAccountsPage({
+    required this.payments,
+    required this.advertisementUsecase,
+  })  : transaction = Transaction(payments),
         super();
 
   final List<Payment> payments;
   final Transaction transaction;
+  final AdvertisementUsecase advertisementUsecase;
 
   @override
   _SettleAccountsPageState createState() => _SettleAccountsPageState();
@@ -45,7 +48,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         body: ListView(
           children: [
             Card(
-              child: _adTopBannerComponent(),
+              child: _adTopBannerComponent(widget.advertisementUsecase),
             ),
             Card(
               child: Column(
@@ -99,8 +102,8 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         ],
       );
 
-  Column _adTopBannerComponent() {
-    final banner = AdvertisementUsecase.shared().settleAccountsTopBanner;
+  Column _adTopBannerComponent(AdvertisementUsecase advertisementUsecase) {
+    final banner = advertisementUsecase.settleAccountsTopBanner;
     return Column(
       children: [
         Container(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -100,7 +100,7 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
       );
 
   Column _adTopBannerComponent() {
-    final banner = AdvertisementUsecase().getSettleAccountsTopBanner();
+    final banner = AdvertisementUsecase.shared().settleAccountsTopBanner;
     return Column(
       children: [
         Container(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -51,35 +51,42 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
       );
 
   List<Card> _settleAccountsComponents(State<SettleAccountsPage> state) {
-    return [
-      Card(
-        child: _adTopBannerComponent(state.widget.advertisementUsecase),
-      ),
-      Card(
-        child: Column(
-          children: [
-            _titleComponent("Payments"),
-            _labelComponent("Items"),
-            ListView(
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
-              children: state.widget.transaction.payments
-                  .map((e) => _paymentComponent(e))
-                  .toList(),
-            ),
-            const SizedBox(
-              height: 16,
-            )
-          ],
+    final components = <Card>[];
+    if (state.widget.advertisementUsecase
+        .isSettleAccountsTopBannerSuccessfullyLoaded()) {
+      components.add(
+        Card(
+          child: _adTopBannerComponent(state.widget.advertisementUsecase),
         ),
-      ),
-      Card(
-        child: _creditorsComponent(state.widget.transaction.creditor),
-      ),
-      Card(
-        child: _settlementComponent(state.widget.transaction.settlement),
-      ),
-    ];
+      );
+    }
+    return components
+      ..addAll([
+        Card(
+          child: Column(
+            children: [
+              _titleComponent("Payments"),
+              _labelComponent("Items"),
+              ListView(
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                children: state.widget.transaction.payments
+                    .map((e) => _paymentComponent(e))
+                    .toList(),
+              ),
+              const SizedBox(
+                height: 16,
+              )
+            ],
+          ),
+        ),
+        Card(
+          child: _creditorsComponent(state.widget.transaction.creditor),
+        ),
+        Card(
+          child: _settlementComponent(state.widget.transaction.settlement),
+        ),
+      ]);
   }
 
   ListTile _titleComponent(String title) => ListTile(

--- a/test/model/usecase/advertisement_usecase_test.dart
+++ b/test/model/usecase/advertisement_usecase_test.dart
@@ -14,5 +14,17 @@ void main() {
         equals("ca-app-pub-3940256099942544/2934735716"),
       );
     });
+
+    test(
+        'isSettleAccountsTopBannerSuccessfullyLoaded_devのsetConfigとWidgetsFlutterBindingの初期化実施後に取得した時、正常応答がない時false',
+        () {
+      dev.setConfig();
+      TestWidgetsFlutterBinding.ensureInitialized();
+      AdvertisementUsecase.shared().settleAccountsTopBanner.responseInfo = null;
+      expect(
+        AdvertisementUsecase.shared().isSettleAccountsTopBannerSuccessfullyLoaded(),
+        equals(false),
+      );
+    });
   });
 }

--- a/test/model/usecase/advertisement_usecase_test.dart
+++ b/test/model/usecase/advertisement_usecase_test.dart
@@ -5,12 +5,12 @@ import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 void main() {
   group('AdvertisementUsecase', () {
     test(
-        'getSettleAccountsTopBanner_devのsetConfigとWidgetsFlutterBindingの初期化実施後に実行した時、IDがテスト用の広告を返す',
+        'settleAccountsTopBanner_devのsetConfigとWidgetsFlutterBindingの初期化実施後に取得した時、IDがテスト用の広告を返す',
         () {
       dev.setConfig();
       TestWidgetsFlutterBinding.ensureInitialized();
       expect(
-        AdvertisementUsecase().getSettleAccountsTopBanner().adUnitId,
+        AdvertisementUsecase.shared().settleAccountsTopBanner.adUnitId,
         equals("ca-app-pub-3940256099942544/2934735716"),
       );
     });


### PR DESCRIPTION
## 概要

広告の読み込みを非同期実行できるようにし、またアプリケーション開始時に当該処理が呼ばれるようにした。
それによって生じるエラー防止のため、読み込み失敗時のエラー制御も追加してある。

## 動作詳細

これまでは、精算画面表示後にロードしに行っていたので、一時的に白くなる時間があった

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153739384-bb5f002b-7c97-4bfc-b47a-350496b24e5a.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153739432-cb8f11e0-c085-41bd-8a26-9dcfbff4690a.png">

また、ネットワーク不良等で広告ロードに失敗した際、レイアウトエラーの可能性があるので、そもそも広告枠が表示されないようにした。

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153740273-408a84b2-f6cc-4aa7-9b30-3a4829fa5a72.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153740237-99db16ad-62bd-40db-9c20-30541bbdee81.png">

## 参考

### シングルトン

https://dart.dev/guides/language/language-tour#factory-constructors

### AdMob公式

https://developers.google.com/admob/flutter/banner

### 広告エラー制御条件

https://github.com/googleads/googleads-mobile-flutter/blob/5bd973c8e92a384de891e0289491b6c279562dba/packages/google_mobile_ads/lib/src/ad_containers.dart#L567-L570