### PR TITLE
AdMobのエラーをCrashlyticsで追跡できるようにする

### DIFF
--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/dev.dart';
@@ -8,6 +9,7 @@ void main() {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
   AdvertisementUsecase.shared().initialize();
+  Firebase.initializeApp();
   runApp(Tatetsu());
 }
 

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/prd.dart';
@@ -8,6 +9,7 @@ void main() {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
   AdvertisementUsecase.shared().initialize();
+  Firebase.initializeApp();
   runApp(Tatetsu());
 }
 

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:tatetsu/config/application_meta.dart';
 
@@ -13,7 +14,15 @@ class AdvertisementUsecase {
       : settleAccountsTopBanner = BannerAd(
           size: AdSize.banner,
           adUnitId: getSettleAccountsTopBannerId(),
-          listener: const BannerAdListener(),
+          listener: BannerAdListener(
+            onAdFailedToLoad: (Ad ad, LoadAdError error) async {
+              await FirebaseCrashlytics.instance.recordError(
+                error,
+                StackTrace.current,
+                reason: 'Ad failed to load: $error',
+              );
+            },
+          ),
           request: const AdRequest(),
         );
 

--- a/lib/model/usecase/advertisement_usecase.dart
+++ b/lib/model/usecase/advertisement_usecase.dart
@@ -16,6 +16,7 @@ class AdvertisementUsecase {
           adUnitId: getSettleAccountsTopBannerId(),
           listener: BannerAdListener(
             onAdFailedToLoad: (Ad ad, LoadAdError error) async {
+              ad.dispose();
               await FirebaseCrashlytics.instance.recordError(
                 error,
                 StackTrace.current,


### PR DESCRIPTION
## 概要

クライアントで何か起きた時に検知できるようにする。Firebase Crashlyticsの非重大エラーとしてカウントする方針。

## 動作確認

広告IDを適当なものにし実行した際、Crashlytics管理画面より閲覧できることを確認

Android|iOS
---|---
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/38374045/153741792-43ca070f-9619-4b01-9ff9-e8d416dd7289.png">|<img width="1187" alt="image" src="https://user-images.githubusercontent.com/38374045/153741763-f7b467a3-3ab1-453d-811e-2ae2a7aa28e0.png">

## 参考

下記が大変参考になった。

### 広告エラー取得

https://developers.google.com/admob/flutter/banner

### 非重大クラッシュ送信

https://firebase.flutter.dev/docs/crashlytics/usage/#non-fatal-crash

### スタックトレース取得

https://stackoverflow.com/questions/13963837/how-do-you-get-the-current-stacktrace-in-dart-for-a-completer-completeexception
