### PR TITLE
小数点第2位が含まれる支払いの精算の精度を上げた

### DIFF
--- a/lib/model/core/double_ext.dart
+++ b/lib/model/core/double_ext.dart
@@ -1,12 +1,12 @@
 extension DoubleExt on double {
-  double floorAtSecondDecimal() =>
-      this == 0 ? 0 : (this * 100).abs().floor() / 100 * (isNegative ? -1 : 1);
+  double roundAtSecondDecimal() =>
+      this == 0 ? 0 : (this * 100).abs().round() / 100 * (isNegative ? -1 : 1);
 
   double minusAtSecondDecimal(double value) =>
-      (((this * 100).toInt() - (value * 100).toInt()) / 100)
-          .floorAtSecondDecimal();
+      (((this * 100).round() - (value * 100).round()) / 100)
+          .roundAtSecondDecimal();
 
   double plusAtSecondDecimal(double value) =>
-      (((this * 100).toInt() + (value * 100).toInt()) / 100)
-          .floorAtSecondDecimal();
+      (((this * 100).round() + (value * 100).round()) / 100)
+          .roundAtSecondDecimal();
 }

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -31,7 +31,7 @@ class Creditor {
     final double dealTarget = min(debt.abs(), credit.abs());
 
     // 精算額はドルにおけるセントまでと考え、0.01を下限とする。誤差は別途表示する
-    final double dealValue = dealTarget.floorAtSecondDecimal();
+    final double dealValue = dealTarget.roundAtSecondDecimal();
     if (dealValue == 0) {
       return null;
     }
@@ -81,7 +81,7 @@ extension CreditorEntriesExt on Map<Participant, double> {
   void _addCredit(Payment payment) => update(
         payment.payer,
         (value) =>
-            (value.plusAtSecondDecimal(payment.price)).floorAtSecondDecimal(),
+            (value.plusAtSecondDecimal(payment.price)).roundAtSecondDecimal(),
       );
 
   void _addDebt(Payment payment) {
@@ -94,7 +94,7 @@ extension CreditorEntriesExt on Map<Participant, double> {
     }
     final fee = payment.price / debtors.length;
     for (final debtor in debtors) {
-      update(debtor, (value) => (value - fee).floorAtSecondDecimal());
+      update(debtor, (value) => (value - fee).roundAtSecondDecimal());
     }
   }
 }

--- a/lib/model/entity/payment.dart
+++ b/lib/model/entity/payment.dart
@@ -12,5 +12,5 @@ class Payment {
     required this.payer,
     required double price,
     required this.owners,
-  }) : price = price.floorAtSecondDecimal();
+  }) : price = price.roundAtSecondDecimal();
 }

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -82,19 +82,19 @@ extension ProceduresExt on List<Procedure> {
       settlementBaseCreditor.entries.update(
         procedure.from,
         (value) =>
-            value.plusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
+            value.plusAtSecondDecimal(procedure.amount.roundAtSecondDecimal()),
       );
       settlementBaseCreditor.entries.update(
         procedure.to,
         (value) =>
-            value.minusAtSecondDecimal(procedure.amount.floorAtSecondDecimal()),
+            value.minusAtSecondDecimal(procedure.amount.roundAtSecondDecimal()),
       );
     }
 
     return Map.fromEntries(
       settlementBaseCreditor.entries.entries
           .toList()
-          .map((e) => MapEntry(e.key, e.value.floorAtSecondDecimal()))
+          .map((e) => MapEntry(e.key, e.value.roundAtSecondDecimal()))
           .where((element) => element.value.abs() != 0),
     );
   }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -205,7 +205,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         key: UniqueKey(),
         onChanged: (String value) {
           payment.price = value.isNotEmpty
-              ? double.parse(value).floorAtSecondDecimal()
+              ? double.parse(value).roundAtSecondDecimal()
               : defaultPaymentPriceValue;
         },
         keyboardType: const TextInputType.numberWithOptions(decimal: true),

--- a/test/model/core/double_ext_test.dart
+++ b/test/model/core/double_ext_test.dart
@@ -3,32 +3,40 @@ import 'package:test/test.dart';
 
 void main() {
   group('DoubleExt', () {
-    test('DoubleExt_floorAtSecondDecimal_0の時、0', () {
-      expect(0.0.floorAtSecondDecimal(), equals(0));
+    test('DoubleExt_roundAtSecondDecimal_0の時、0', () {
+      expect(0.0.roundAtSecondDecimal(), equals(0));
     });
 
-    test('DoubleExt_floorAtSecondDecimal_0.01未満と判断される値が切り捨てられる', () {
-      expect(28.009999999999996.floorAtSecondDecimal(), equals(28));
+    test('DoubleExt_roundAtSecondDecimal_0.01未満と判断される値が繰り上がる', () {
+      expect(28.004999999999998.roundAtSecondDecimal(), equals(28.01));
     });
 
-    test('DoubleExt_floorAtSecondDecimal_演算の結果0.01未満と判断される負の値が切り捨てられる', () {
-      expect((-10 + 9.9900001).floorAtSecondDecimal(), equals(0));
+    test('DoubleExt_roundAtSecondDecimal_0.01未満と判断される値が切り捨てられる', () {
+      expect(28.004999999999997.roundAtSecondDecimal(), equals(28));
     });
 
-    test('DoubleExt_floorAtSecondDecimal_0.01以上と判断される値は残る', () {
-      expect(28.009999999999997.floorAtSecondDecimal(), equals(28.01));
+    test('DoubleExt_roundAtSecondDecimal_演算の結果0.01以上と判断される負の値が繰り上がる', () {
+      expect((-10 + 9.9950000000000001).roundAtSecondDecimal(), equals(-0.01));
+    });
+
+    test('DoubleExt_roundAtSecondDecimal_演算の結果0.01未満と判断される負の値が切り捨てられる', () {
+      expect((-10 + 9.9950000000000002).roundAtSecondDecimal(), equals(0));
     });
 
     test('DoubleExt_minusAtSecondDecimal_0.01以上の値は残る', () {
       expect(6.67.minusAtSecondDecimal(6.66), equals(0.01));
     });
 
+    test('DoubleExt_minusAtSecondDecimal_60.45に対して20.15を作用させると40.3', () {
+      expect(60.45.minusAtSecondDecimal(20.15), equals(40.3));
+    });
+
     test('DoubleExt_minusAtSecondDecimal_言語の特性上0.01以上と判断される値は残る', () {
-      expect(6.6699999999999995.minusAtSecondDecimal(6.66), equals(0.01));
+      expect(6.6649999999999996.minusAtSecondDecimal(6.66), equals(0.01));
     });
 
     test('DoubleExt_minusAtSecondDecimal_言語の特性上0.01未満と判断される値は残らない', () {
-      expect(6.6699999999999994.minusAtSecondDecimal(6.66), equals(0));
+      expect(6.6649999999999995.minusAtSecondDecimal(6.66), equals(0));
     });
 
     test('DoubleExt_plusAtSecondDecimal_-0.01以下の値はと判断される値は残る', () {
@@ -36,11 +44,11 @@ void main() {
     });
 
     test('DoubleExt_minusAtSecondDecimal_言語の特性上0.01以上と判断される値は残る', () {
-      expect((-6.6699999999999995).plusAtSecondDecimal(6.66), equals(-0.01));
+      expect((-6.6649999999999996).plusAtSecondDecimal(6.66), equals(-0.01));
     });
 
     test('DoubleExt_minusAtSecondDecimal_言語の特性上0.01未満と判断される値は残らない', () {
-      expect((-6.6699999999999994).plusAtSecondDecimal(6.66), equals(0));
+      expect((-6.6649999999999995).plusAtSecondDecimal(6.66), equals(0));
     });
   });
 }

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -242,8 +242,8 @@ void main() {
 
     test('extractSettlement_精算対象が0.01未満の時、nullで、プロパティに影響を与えない', () {
       final testEntries = {
-        testParticipant1: -21.00999999999999999,
-        testParticipant2: 0.00999999999999999,
+        testParticipant1: -21.0049999999999999996,
+        testParticipant2: 0.0049999999999999996,
         testParticipant3: 21.0,
       };
       final testCreditor = Creditor(payments: dummyPayments)
@@ -259,12 +259,47 @@ void main() {
       expect(mapEquals(testCreditor.entries, testEntries), true);
     });
 
+    test('extractSettlement_精算対象が0.01未満だが浮動小数点的に0.01の表現に近い時、精算が発生し、プロパティに反映される',
+        () {
+      final testEntries = {
+        testParticipant1: -21.0049999999999999997,
+        testParticipant2: 0.0049999999999999997,
+        testParticipant3: 21.0,
+      };
+      final testCreditor = Creditor(payments: dummyPayments)
+        ..entries = testEntries;
+
+      expect(
+        testCreditor
+            .extractSettlement(
+              from: testParticipant1,
+              to: testParticipant2,
+            )!
+            .isEqualTo(
+              Procedure(
+                from: testParticipant1,
+                to: testParticipant2,
+                amount: 0.01,
+              ),
+            ),
+        equals(true),
+      );
+      expect(
+        mapEquals(testCreditor.entries, {
+          testParticipant1: -20.994999999999997,
+          testParticipant2: -0.005,
+          testParticipant3: 21.0
+        }),
+        true,
+      );
+    });
+
     test(
         'extractSettlement_精算対象が0.01未満の値が含まれる浮動小数点の時、誤差の含まれる精算となり、プロパティに当該の精算結果が適用される',
         () {
       final testEntries = {
-        testParticipant1: -28.00999999999997,
-        testParticipant2: 28.00999999999998,
+        testParticipant1: -28.00499999999997,
+        testParticipant2: 28.00499999999998,
         testParticipant3: -0.00000000000001,
       };
       final testCreditor = Creditor(payments: dummyPayments)
@@ -284,11 +319,11 @@ void main() {
       );
       expect(
         mapEquals(testCreditor.entries, {
-          testParticipant1: -0.009999999999969589,
-          testParticipant2: 0.009999999999980247,
+          testParticipant1: -0.0049999999999705835,
+          testParticipant2: 0.004999999999981242,
           testParticipant3: -1e-14,
         }),
-        true,
+        equals(true),
       );
     });
 
@@ -517,12 +552,24 @@ void main() {
       );
     });
 
+    test('getError_立替が2件以上で、合計値が小数点2桁まで見れば0だが浮動小数点数として0でない時、値が存在する', () {
+      expect(
+        (Creditor(payments: dummyPayments)
+              ..entries = {
+                testParticipant1: 10,
+                testParticipant2: -10.0049999999999999,
+              })
+            .getError(),
+        equals(-0.01),
+      );
+    });
+
     test('getError_立替が2件以上で、正確な合計値が0にはならないが小数点2桁以下無視した合計値が0になる時、0', () {
       expect(
         (Creditor(payments: dummyPayments)
               ..entries = {
                 testParticipant1: 10,
-                testParticipant2: -10.00999999999999,
+                testParticipant2: -10.0049999999999998,
               })
             .getError(),
         equals(0),
@@ -878,7 +925,7 @@ void main() {
         equals({
           testParticipant1: -9333.33,
           testParticipant2: -14883.33,
-          testParticipant3: 24216.66
+          testParticipant3: 24216.67
         }),
       );
     });

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -169,7 +169,7 @@ void main() {
         equals({
           testParticipant1: -9333.33,
           testParticipant2: -14883.33,
-          testParticipant3: 24216.66
+          testParticipant3: 24216.67
         }),
       );
     });
@@ -418,7 +418,7 @@ void main() {
             Procedure(
               from: testParticipant2,
               to: testParticipant1,
-              amount: 6.66,
+              amount: 6.67,
             ),
             Procedure(
               from: testParticipant3,
@@ -430,7 +430,7 @@ void main() {
         equals(true),
       );
       expect(
-        mapEquals(testSettlement.errors, {testParticipant1: 0.01}),
+        mapEquals(testSettlement.errors, {testParticipant3: -0.01}),
         equals(true),
       );
     });
@@ -1666,7 +1666,7 @@ void main() {
     });
 
     test(
-        'ProceduresExt_getSettlementErrors_0.01未満の精算値は切り捨てられて、与えた立替の合算値に反映された値',
+        'ProceduresExt_getSettlementErrors_0.01未満の精算値は四捨五入されて、与えた立替の合算値に反映された値',
         () {
       final List<Payment> testPayments = [
         Payment(
@@ -1690,8 +1690,8 @@ void main() {
             toward: Creditor(payments: testPayments),
           ),
           {
-            testParticipant1: 20 - 5,
-            testParticipant2: -10 + 5,
+            testParticipant1: 20 - 5.01,
+            testParticipant2: -10 + 5.01,
             testParticipant3: -10
           },
         ),


### PR DESCRIPTION
## 概要

切り捨てをやめ、四捨五入へ。
`60.45` の処置で、 60.45 - 20.15が浮動小数的には40.3未満の表現になる。それの救済。

## 変更詳細

### 60.45

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153754688-7a0d1c81-c884-43aa-be47-106d3e87dbab.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153754645-e2fad52e-1364-42fb-979b-128475ffec1d.png">

### 20

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153754701-9700a27c-6f09-46b1-b02b-204c63cc5ec6.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/153754651-b855169c-ea9f-498d-aa80-c4c626abc3b5.png">

