### PR TITLE
l10n導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 .pub/
 /build/
 
+# Flutter customize
+lib/l10n/built
+
 # Web related
 lib/generated_plugin_registrant.dart
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:lint/analysis_options.yaml
+analyzer:
+  exclude:
+  - 'lib/l10n/built'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,6 +110,10 @@ stages:
         channel: 'stable'
         version: 'latest'
     - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter gen-l10n'
+        $FLUTTERTOOLPATH/flutter gen-l10n
+      displayName: 'Build l10n (scratch)'
+    - script: |
         echo '>> $FLUTTERTOOLPATH/flutter pub get'
         $FLUTTERTOOLPATH/flutter pub get
         echo '>> $FLUTTERTOOLPATH/flutter analyze'
@@ -221,6 +225,10 @@ stages:
         mode: 'auto'
         channel: 'stable'
         version: 'latest'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter gen-l10n'
+        $FLUTTERTOOLPATH/flutter gen-l10n
+      displayName: 'Build l10n (scratch)'
     - script: |
         echo '>> $FLUTTERTOOLPATH/flutter pub get'
         $FLUTTERTOOLPATH/flutter pub get

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,5 @@
+arb-dir: lib/l10n
+template-arb-file: app_en.arb
+output-localization-file: app_localizations.dart
+output-dir: lib/l10n/built # 公式にない記述。flutter analyzeが、flutter_genに対してdepend_on_referenced_packagesを起こさなくなったら、消せそう
+synthetic-package: false # 公式にない記述。flutter analyzeが、flutter_genに対してdepend_on_referenced_packagesを起こさなくなったら、消せそう

--- a/lib/config/application_meta.dart
+++ b/lib/config/application_meta.dart
@@ -23,11 +23,11 @@ ThemeData getAppTheme() {
   }
 }
 
-String getEntryPageTitle() {
+String getEntryPageTitlePrefix() {
   try {
-    return FlavorConfig.instance.variables["entry_page_title"] as String;
+    return FlavorConfig.instance.variables["entry_page_title_prefix"] as String;
   } catch (e) {
-    return "Participants";
+    return "";
   }
 }
 

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -9,7 +9,7 @@ void setConfig() => FlavorConfig(
           primarySwatch: Colors.red,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
-        "entry_page_title": "title",
+        "entry_page_title_prefix": "[Env]",
         "settle_accounts_top_banner_id_ios":
             "ca-app-pub-3940256099942544/2934735716",
         "settle_accounts_top_banner_id_android":

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,0 +1,6 @@
+{
+  "participants": "Participants",
+  "@participants": {
+    "description": "activities participants"
+  }
+}

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,0 +1,3 @@
+{
+  "participants": "メンバー"
+}

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -28,7 +28,7 @@ class Tatetsu extends StatelessWidget {
         title: getAppTitle(),
         theme: getAppTheme(),
         home: InputParticipantsPage(
-          title: getEntryPageTitle(),
+          titlePrefix: getEntryPageTitlePrefix(),
         ),
       );
 }

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/dev.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
@@ -18,6 +19,7 @@ class Tatetsu extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MaterialApp(
         localizationsDelegates: const [
+          AppLocalizations.delegate,
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/dev.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
@@ -16,6 +17,12 @@ void main() {
 class Tatetsu extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MaterialApp(
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', ''), Locale('ja', '')],
         title: getAppTitle(),
         theme: getAppTheme(),
         home: InputParticipantsPage(

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -28,7 +28,7 @@ class Tatetsu extends StatelessWidget {
         title: getAppTitle(),
         theme: getAppTheme(),
         home: InputParticipantsPage(
-          title: getEntryPageTitle(),
+          titlePrefix: getEntryPageTitlePrefix(),
         ),
       );
 }

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/prd.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
@@ -16,6 +17,12 @@ void main() {
 class Tatetsu extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MaterialApp(
+        localizationsDelegates: const [
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: const [Locale('en', ''), Locale('ja', '')],
         title: getAppTitle(),
         theme: getAppTheme(),
         home: InputParticipantsPage(

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/config/prd.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
@@ -18,6 +19,7 @@ class Tatetsu extends StatelessWidget {
   @override
   Widget build(BuildContext context) => MaterialApp(
         localizationsDelegates: const [
+          AppLocalizations.delegate,
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,
           GlobalCupertinoLocalizations.delegate,

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -1,13 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
 
 class InputParticipantsPage extends StatefulWidget {
-  const InputParticipantsPage({required this.title}) : super();
+  const InputParticipantsPage({required this.titlePrefix}) : super();
 
-  final String title;
+  final String titlePrefix;
 
   @override
   _InputParticipantsPageState createState() => _InputParticipantsPageState();
@@ -22,7 +23,12 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: Scaffold(
         appBar: AppBar(
-          title: Text(widget.title),
+          title: Text(
+            [
+              widget.titlePrefix,
+              AppLocalizations.of(context)?.participants ?? "Participants"
+            ].join(" "),
+          ),
           actions: <Widget>[
             TextButton(
               style: TextButton.styleFrom(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -202,6 +202,11 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.2"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_flavor: ^3.0.3
+  flutter_localizations:
+    sdk: flutter
   google_mobile_ads: ^1.1.0
   intl: ^0.17.0
   share_plus: ^3.0.4

--- a/test/config/application_meta_test.dart
+++ b/test/config/application_meta_test.dart
@@ -27,14 +27,14 @@ void main() {
       expect(getAppTheme().primaryColor, tatetsuViolet);
     });
 
-    test('getEntryPageTitle_devのsetConfig実施後に実行した時、devの接頭辞のついたページ名を返す', () {
+    test('getEntryPageTitlePrefix_devのsetConfig実施後に実行した時、接頭辞devを返す', () {
       dev.setConfig();
-      expect(getEntryPageTitle(), equals("[Dev] Participants"));
+      expect(getEntryPageTitlePrefix(), equals("[Dev]"));
     });
 
-    test('getEntryPageTitle_prdのsetConfig実施後に実行した時、接頭辞のないページ名を返す', () {
+    test('getEntryPageTitlePrefix_prdのsetConfig実施後に実行した時、空を返す', () {
       prd.setConfig();
-      expect(getEntryPageTitle(), equals("Participants"));
+      expect(getEntryPageTitlePrefix(), equals(""));
     });
 
     test('getSettleAccountsTopBannerId_devのsetConfig実施後に実行した時、AdMobのテスト広告IDを返す', () {


### PR DESCRIPTION
## 概要

ローカライゼーションの導入。
まずは日本語圏ユーザーにわかりやすい表現を目指す

## 変更詳細

日本語設定にした端末の表示が下記。

### 立替参加者入力画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155182887-08a8889a-00ee-4acc-9c63-942bda3d3fec.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155180621-44bfe90b-6e5d-4695-8429-ec117c14b3f6.png">

## TODO

- 日本語化対応全体化
- 人名サンプルは日本語は日本人名対応しておきたいところ
- エントリーポイントが肥大化してきたのでファイルを分けるリファクタリングをする

## 参考

### そもそもl10nとかm17nとか

https://mabots.hatenablog.com/entry/20120214/1329225300

### l10n公式

https://docs.flutter.dev/development/accessibility-and-localization/internationalization

### l10nしたけど depend_on_referenced_packages warning が出てしまう問題

https://dart-lang.github.io/linter/lints/depend_on_referenced_packages.html
https://stackoverflow.com/questions/64574620/target-of-uri-doesnt-exist-packageflutter-gen-gen-l10n-gallery-localizations
https://zenn.dev/aryzae/articles/0555959ac3800e
https://github.com/flutter/flutter/issues/96839
