### PR TITLE
l10n 固定テキストの日本語化

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -62,5 +62,21 @@
   "summarySettlementsErrorRestsLabel": "Error rests",
   "@summarySettlementsErrorRestsLabel": {
     "description": "summary label"
+  },
+  "summaryMessageTitle": "Settlements summary",
+  "@summaryMessageTitle": {
+    "description": "summary message title"
+  },
+  "summaryMessagePaymentsLabel": "Payments",
+  "@summaryMessagePaymentsLabel": {
+    "description": "summary message label"
+  },
+  "summaryMessageCreditorsLabel": "Creditors",
+  "@summaryMessageCreditorsLabel": {
+    "description": "summary message label"
+  },
+  "summaryMessageSettlementLabel": "Settlement",
+  "@summaryMessageSettlementLabel": {
+    "description": "summary message label"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,6 +3,14 @@
   "@participants": {
     "description": "activities participants"
   },
+  "payments": "Payments",
+  "@payments": {
+    "description": "activities payments"
+  },
+  "creditSummaries": "Credit Summaries",
+  "@creditSummaries": {
+    "description": "activities credit summaries"
+  },
   "examplePrefix": "e.g.",
   "@examplePrefix": {
     "description": "input form information"
@@ -14,5 +22,45 @@
   "samplePaymentPrice": "66",
   "@samplePaymentPrice": {
     "description": "payment input form information"
+  },
+  "paymentPayerLabel": "Payer",
+  "@paymentPayerLabel": {
+    "description": "payment input form label"
+  },
+  "paymentPriceLabel": "Price",
+  "@paymentPriceLabel": {
+    "description": "payment input form label"
+  },
+  "summaryPaymentsTitle": "Payments",
+  "@summaryPaymentsTitle": {
+    "description": "summary title"
+  },
+  "summaryPaymentsItemLabel": "Items",
+  "@summaryPaymentsItemLabel": {
+    "description": "summary label"
+  },
+  "summaryCreditorsTitle": "Creditors",
+  "@summaryCreditorsTitle": {
+    "description": "summary title"
+  },
+  "summaryCreditorsBalanceLabel": "Balance",
+  "@summaryCreditorsBalanceLabel": {
+    "description": "summary label"
+  },
+  "summaryCreditorsErrorLabel": "Error",
+  "@summaryCreditorsErrorLabel": {
+    "description": "summary label"
+  },
+  "summarySettlementsTitle": "Settlements",
+  "@summarySettlementsTitle": {
+    "description": "summary title"
+  },
+  "summarySettlementsProceduresLabel": "Procedures",
+  "@summarySettlementsProceduresLabel": {
+    "description": "summary label"
+  },
+  "summarySettlementsErrorRestsLabel": "Error rests",
+  "@summarySettlementsErrorRestsLabel": {
+    "description": "summary label"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -6,5 +6,9 @@
   "examplePrefix": "e.g.",
   "@examplePrefix": {
     "description": "input form information"
+  },
+  "samplePaymentTitle": "Lunch at the nice cafe",
+  "@samplePaymentTitle": {
+    "description": "payment input form information"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -10,5 +10,9 @@
   "samplePaymentTitle": "Lunch at the nice cafe",
   "@samplePaymentTitle": {
     "description": "payment input form information"
+  },
+  "samplePaymentPrice": "66",
+  "@samplePaymentPrice": {
+    "description": "payment input form information"
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -2,5 +2,9 @@
   "participants": "Participants",
   "@participants": {
     "description": "activities participants"
+  },
+  "examplePrefix": "e.g.",
+  "@examplePrefix": {
+    "description": "input form information"
   }
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,6 +1,18 @@
 {
   "participants": "メンバー",
+  "payments": "会計",
+  "creditSummaries": "立替まとめ",
   "examplePrefix": "例.",
   "samplePaymentTitle": "昼食代",
-  "samplePaymentPrice": "4980"
+  "samplePaymentPrice": "4980",
+  "paymentPayerLabel": "払った人",
+  "paymentPriceLabel": "値段",
+  "summaryPaymentsTitle": "会計",
+  "summaryPaymentsItemLabel": "品目",
+  "summaryCreditorsTitle": "立替",
+  "summaryCreditorsBalanceLabel": "貸借状況",
+  "summaryCreditorsErrorLabel": "誤差",
+  "summarySettlementsTitle": "精算",
+  "summarySettlementsProceduresLabel": "手順",
+  "summarySettlementsErrorRestsLabel": "残り誤差"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -14,5 +14,9 @@
   "summaryCreditorsErrorLabel": "誤差",
   "summarySettlementsTitle": "精算",
   "summarySettlementsProceduresLabel": "手順",
-  "summarySettlementsErrorRestsLabel": "残り誤差"
+  "summarySettlementsErrorRestsLabel": "残り誤差",
+  "summaryMessageTitle": "精算概要",
+  "summaryMessagePaymentsLabel": "会計",
+  "summaryMessageCreditorsLabel": "立替",
+  "summaryMessageSettlementLabel": "精算"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,4 +1,5 @@
 {
   "participants": "メンバー",
-  "examplePrefix": "例."
+  "examplePrefix": "例.",
+  "samplePaymentTitle": "昼食代"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,5 +1,6 @@
 {
   "participants": "メンバー",
   "examplePrefix": "例.",
-  "samplePaymentTitle": "昼食代"
+  "samplePaymentTitle": "昼食代",
+  "samplePaymentPrice": "4980"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,3 +1,4 @@
 {
-  "participants": "メンバー"
+  "participants": "メンバー",
+  "examplePrefix": "例."
 }

--- a/lib/model/entity/creditor.dart
+++ b/lib/model/entity/creditor.dart
@@ -55,10 +55,10 @@ class Creditor {
 
   bool hasError() => getError() != 0;
 
-  String toSummary() => [
-    "[Creditors]",
-    ...entries.entries.map((e) => "${e.key.displayName}: ${e.value}")
-  ].join("\n");
+  String toSummary(String label) => [
+        "[$label]",
+        ...entries.entries.map((e) => "${e.key.displayName}: ${e.value}")
+      ].join("\n");
 }
 
 extension PaymentsExt on List<Payment> {

--- a/lib/model/entity/settlement.dart
+++ b/lib/model/entity/settlement.dart
@@ -7,8 +7,8 @@ class Settlement {
 
   Settlement({required this.procedures, required this.errors});
 
-  String toSummary() => [
-        "[Settlement]",
+  String toSummary(String label) => [
+        "[$label]",
         ...procedures.map(
           (e) => "${e.from.displayName} -> ${e.to.displayName}: ${e.amount}",
         )

--- a/lib/model/entity/transaction.dart
+++ b/lib/model/entity/transaction.dart
@@ -1,5 +1,7 @@
 import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
@@ -17,13 +19,29 @@ class Transaction {
       : creditor = payments.toCreditor(),
         settlement = payments.toCreditor().toSettlement();
 
-  SummaryMessage toSummaryMessage({DateTime? datetime}) => SummaryMessage(
-        title:
-            "Settlements on ${DateFormat.yMd().add_Hm().format(datetime ?? DateTime.now())}",
+  SummaryMessage toSummaryMessage({
+    required BuildContext context,
+    DateTime? datetime,
+  }) =>
+      SummaryMessage(
+        title: [
+          AppLocalizations.of(context)?.summaryMessageTitle ??
+              "Settlements summary",
+          "[ ${DateFormat.yMd(Localizations.localeOf(context).languageCode).add_Hm().format(datetime ?? DateTime.now())} ]"
+        ].join(" "),
         body: [
-          payments.toSummary(),
-          creditor.toSummary(),
-          settlement.toSummary()
+          payments.toSummary(
+            AppLocalizations.of(context)?.summaryMessagePaymentsLabel ??
+                "Payments",
+          ),
+          creditor.toSummary(
+            AppLocalizations.of(context)?.summaryMessageCreditorsLabel ??
+                "Creditors",
+          ),
+          settlement.toSummary(
+            AppLocalizations.of(context)?.summaryMessageSettlementLabel ??
+                "Settlement",
+          )
         ].join("\n\n"),
       );
 }
@@ -31,8 +49,8 @@ class Transaction {
 extension PaymentsExt on List<Payment> {
   Creditor toCreditor() => Creditor(payments: this);
 
-  String toSummary() => [
-        "[Payments]",
+  String toSummary(String label) => [
+        "[$label]",
         ...map(
           (e) => "${e.title}(${e.payer.displayName}): ${e.price.toString()}",
         ),

--- a/lib/ui/core/double_ext.dart
+++ b/lib/ui/core/double_ext.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:tatetsu/ui/core/string_ext.dart';
+
+extension DoubleExt on double {
+  String toHintText(BuildContext context) {
+    if (Localizations.localeOf(context).languageCode == "ja") {
+      return toInt().toString().toHintText(context);
+    }
+    return toString().toHintText(context);
+  }
+}

--- a/lib/ui/core/string_ext.dart
+++ b/lib/ui/core/string_ext.dart
@@ -1,3 +1,7 @@
+import 'package:flutter/material.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
+
 extension StringExt on String {
-  String toHintText() => "e.g. $this";
+  String toHintText(BuildContext context) =>
+      [AppLocalizations.of(context)?.examplePrefix ?? "e.g.", this].join(" ");
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -209,7 +209,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       Text("Price", style: Theme.of(context).textTheme.labelMedium),
       TextFormField(
         decoration: InputDecoration(
-          hintText: defaultPaymentPriceValue.toString().toHintText(context),
+          hintText: defaultPaymentPriceValue.toHintText(context),
         ),
         initialValue:
             payment.hasUserSpecifiedPrice ? payment.price.toString() : null,

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -137,7 +137,8 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     final String defaultPaymentTitle = payment.title;
     return ListTile(
       title: TextFormField(
-        decoration: InputDecoration(hintText: defaultPaymentTitle.toHintText()),
+        decoration:
+            InputDecoration(hintText: defaultPaymentTitle.toHintText(context)),
         initialValue: payment.hasUserSpecifiedTitle ? payment.title : null,
         key: UniqueKey(),
         onChanged: (String value) {
@@ -202,7 +203,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       Text("Price", style: Theme.of(context).textTheme.labelMedium),
       TextFormField(
         decoration: InputDecoration(
-          hintText: defaultPaymentPriceValue.toString().toHintText(),
+          hintText: defaultPaymentPriceValue.toString().toHintText(context),
         ),
         initialValue:
             payment.hasUserSpecifiedPrice ? payment.price.toString() : null,

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -32,7 +32,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         onWillPop: _showDiscardConfirmDialogIfNeeded,
         child: Scaffold(
           appBar: AppBar(
-            title: const Text("Payments"),
+            title: Text(AppLocalizations.of(context)?.payments ?? "Payments"),
             actions: <Widget>[
               TextButton(
                 style: TextButton.styleFrom(
@@ -175,7 +175,10 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
 
   List<Widget> _payerView(PaymentComponent payment) {
     return [
-      Text("Payer", style: Theme.of(context).textTheme.labelMedium),
+      Text(
+        AppLocalizations.of(context)?.paymentPayerLabel ?? "Payer",
+        style: Theme.of(context).textTheme.labelMedium,
+      ),
       DropdownButton<Participant>(
         value: payment.payer,
         onChanged: (Participant? newValue) {
@@ -206,7 +209,10 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     final double defaultPaymentPriceValue = payment.price;
     return [
       const SizedBox(height: 16),
-      Text("Price", style: Theme.of(context).textTheme.labelMedium),
+      Text(
+        AppLocalizations.of(context)?.paymentPriceLabel ?? "Price",
+        style: Theme.of(context).textTheme.labelMedium,
+      ),
       TextFormField(
         decoration: InputDecoration(
           hintText: defaultPaymentPriceValue.toHintText(context),

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,16 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
+import 'package:tatetsu/ui/core/double_ext.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
-  InputAccountingDetailPage({required this.participants})
-      : payments = [PaymentComponent.sample(participants: participants)],
-        super();
+  const InputAccountingDetailPage({
+    required this.participants,
+    required this.payments,
+  }) : super();
 
   final List<Participant> participants;
   final List<PaymentComponent> payments;
@@ -84,7 +87,10 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   Future<bool> _showDiscardConfirmDialogIfNeeded() =>
-      widget.payments.hasOnlySampleElement(onParticipants: widget.participants)
+      widget.payments.hasOnlySampleElement(
+        onParticipants: widget.participants,
+        context: context,
+      )
           ? Future(() => true)
           : showDialog<bool>(
               context: context,

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 
@@ -17,8 +19,11 @@ class PaymentComponent {
       : payer = participants.first,
         owners = Map.fromIterables(participants, participants.map((_) => true));
 
-  PaymentComponent.sample({required List<Participant> participants})
-      : title = "Lunch at the nice cafe",
+  PaymentComponent.sample({
+    required List<Participant> participants,
+    required BuildContext context,
+  })  : title =
+            AppLocalizations.of(context)?.samplePaymentTitle ?? "Lunch at the nice cafe",
         payer = participants.first,
         price = 66,
         owners = Map.fromIterables(participants, participants.map((_) => true));
@@ -28,11 +33,15 @@ class PaymentComponent {
 }
 
 extension PaymentComponentsExt on List<PaymentComponent> {
-  bool hasOnlySampleElement({required List<Participant> onParticipants}) {
+  bool hasOnlySampleElement({
+    required List<Participant> onParticipants,
+    required BuildContext context,
+  }) {
     if (length != 1) {
       return false;
     }
-    final sampleElement = PaymentComponent.sample(participants: onParticipants);
+    final sampleElement =
+        PaymentComponent.sample(participants: onParticipants, context: context);
     return first.title == sampleElement.title &&
         first.payer == sampleElement.payer &&
         first.price == sampleElement.price &&

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -25,7 +25,9 @@ class PaymentComponent {
   })  : title =
             AppLocalizations.of(context)?.samplePaymentTitle ?? "Lunch at the nice cafe",
         payer = participants.first,
-        price = 66,
+        price = double.parse(
+          AppLocalizations.of(context)?.samplePaymentPrice ?? "66",
+        ),
         owners = Map.fromIterables(participants, participants.map((_) => true));
 
   Payment toPayment() =>

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -101,7 +101,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
         Expanded(
           child: TextFormField(
             decoration:
-                InputDecoration(hintText: defaultParticipantName.toHintText()),
+                InputDecoration(hintText: defaultParticipantName.toHintText(context)),
             key: UniqueKey(),
             initialValue: participant.hasUserSpecifiedDisplayName
                 ? participant.displayName

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -4,6 +4,7 @@ import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
+import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 
 class InputParticipantsPage extends StatefulWidget {
   const InputParticipantsPage({required this.titlePrefix}) : super();
@@ -85,7 +86,15 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
     Navigator.of(context).push(
       MaterialPageRoute(
         builder: (BuildContext context) {
-          return InputAccountingDetailPage(participants: _participants);
+          return InputAccountingDetailPage(
+            participants: _participants,
+            payments: [
+              PaymentComponent.sample(
+                participants: _participants,
+                context: context,
+              )
+            ],
+          );
         },
       ),
     );

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -38,7 +38,8 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                 primary: Theme.of(context).colorScheme.onPrimary,
               ),
               onPressed: () {
-                final summaryMessage = widget.transaction.toSummaryMessage();
+                final summaryMessage =
+                    widget.transaction.toSummaryMessage(context: context);
                 Share.share(summaryMessage.body, subject: summaryMessage.title);
               },
               child: const Icon(

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
@@ -28,7 +29,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
   @override
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
-          title: const Text("Credit Summaries"),
+          title: Text(
+            AppLocalizations.of(context)?.creditSummaries ?? "Credit Summaries",
+          ),
           actions: [
             TextButton(
               style: TextButton.styleFrom(
@@ -65,8 +68,14 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
         Card(
           child: Column(
             children: [
-              _titleComponent("Payments"),
-              _labelComponent("Items"),
+              _titleComponent(
+                AppLocalizations.of(context)?.summaryPaymentsTitle ??
+                    "Payments",
+              ),
+              _labelComponent(
+                AppLocalizations.of(context)?.summaryPaymentsItemLabel ??
+                    "Items",
+              ),
               ListView(
                 shrinkWrap: true,
                 physics: const NeverScrollableScrollPhysics(),
@@ -168,11 +177,15 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
 
   Column _creditorsComponent(Creditor creditor) {
     final List<Widget> baseCreditorsElements = [
-      _titleComponent("Creditors"),
+      _titleComponent(
+        AppLocalizations.of(context)?.summaryCreditorsTitle ?? "Creditors",
+      ),
     ];
 
     baseCreditorsElements.addAll([
-      _labelComponent("Balance"),
+      _labelComponent(
+        AppLocalizations.of(context)?.summaryCreditorsBalanceLabel ?? "Balance",
+      ),
       ListView(
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
@@ -188,7 +201,9 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
 
     if (creditor.hasError()) {
       baseCreditorsElements.addAll([
-        _labelComponent("Error"),
+        _labelComponent(
+          AppLocalizations.of(context)?.summaryCreditorsErrorLabel ?? "Error",
+        ),
         _creditorErrorComponent(creditor.getError()),
         const SizedBox(
           height: 8,
@@ -269,11 +284,16 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
 
   Column _settlementComponent(Settlement settlement) {
     final List<Widget> baseSettlementElements = [
-      _titleComponent("Settlements"),
+      _titleComponent(
+        AppLocalizations.of(context)?.summarySettlementsTitle ?? "Settlements",
+      ),
     ];
 
     baseSettlementElements.addAll([
-      _labelComponent("Procedures"),
+      _labelComponent(
+        AppLocalizations.of(context)?.summarySettlementsProceduresLabel ??
+            "Procedures",
+      ),
       ListView(
         shrinkWrap: true,
         physics: const NeverScrollableScrollPhysics(),
@@ -287,7 +307,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
 
     if (settlement.errors.isNotEmpty) {
       baseSettlementElements.addAll([
-        _labelComponent("Error rests"),
+        _labelComponent(
+          AppLocalizations.of(context)?.summarySettlementsErrorRestsLabel ??
+              "Error rests",
+        ),
         ListView(
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),

--- a/test/model/entity/creditor_test.dart
+++ b/test/model/entity/creditor_test.dart
@@ -629,7 +629,8 @@ void main() {
       ];
 
       expect(
-        (Creditor(payments: dummyPayments)..entries = {}).toSummary(),
+        (Creditor(payments: dummyPayments)..entries = {})
+            .toSummary("Creditors"),
         equals("[Creditors]"),
       );
     });
@@ -648,7 +649,7 @@ void main() {
 
       expect(
         (Creditor(payments: dummyPayments)..entries = {testParticipant1: 30})
-            .toSummary(),
+            .toSummary("Creditors"),
         equals("[Creditors]\ntestName1: 30.0"),
       );
     });
@@ -672,7 +673,7 @@ void main() {
                 testParticipant2: -100,
                 testParticipant3: 4000
               })
-            .toSummary(),
+            .toSummary("Creditors"),
         equals(
           "[Creditors]\ntestName1: 30.0\ntestName2: -100.0\ntestName3: 4000.0",
         ),

--- a/test/model/entity/settlement_test.dart
+++ b/test/model/entity/settlement_test.dart
@@ -37,7 +37,7 @@ void main() {
 
     test('toSummary_procedures属性に空配列を渡した時、ラベルのみを返す', () {
       expect(
-        Settlement(procedures: [], errors: {}).toSummary(),
+        Settlement(procedures: [], errors: {}).toSummary("Settlement"),
         equals("[Settlement]"),
       );
     });
@@ -49,7 +49,7 @@ void main() {
             Procedure(from: testParticipant1, to: testParticipant2, amount: 30),
           ],
           errors: {},
-        ).toSummary(),
+        ).toSummary("Settlement"),
         equals(
           "[Settlement]\ntestName1 -> testName2: 30.0",
         ),
@@ -73,7 +73,7 @@ void main() {
             ),
           ],
           errors: {},
-        ).toSummary(),
+        ).toSummary("Settlement"),
         equals(
           "[Settlement]\ntestName1 -> testName2: 30.0\ntestName2 -> testName3: 400.0\ntestName4 -> testName1: 5000.0",
         ),

--- a/test/model/entity/transaction_test.dart
+++ b/test/model/entity/transaction_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/creditor.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/entity/payment.dart';
 import 'package:tatetsu/model/entity/procedure.dart';
 import 'package:tatetsu/model/entity/transaction.dart';
-import 'package:test/test.dart';
 
 void main() {
   final Participant testParticipant1 = Participant("testName1");
@@ -174,7 +177,9 @@ void main() {
       );
     });
 
-    test('toSummaryMessage_title属性がSettlements on から始まる文字列である', () {
+    testWidgets(
+        'toSummaryMessage_英語設定の時、title属性がSettlements summary [から始まる英語文字列である',
+        (WidgetTester tester) async {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -188,16 +193,33 @@ void main() {
         ),
       ];
 
-      expect(
-        Transaction(testPayments)
-            .toSummaryMessage()
-            .title
-            .startsWith("Settlements on "),
-        equals(true),
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(context: context)
+                    .title
+                    .startsWith("Settlements summary ["),
+                equals(true),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
       );
     });
 
-    test('toSummaryMessage_title属性がyMd Hm形式の文字列である', () {
+    testWidgets('toSummaryMessage_日本語設定の時、title属性が精算概要 [から始まる英語文字列である',
+        (WidgetTester tester) async {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -211,17 +233,201 @@ void main() {
         ),
       ];
 
-      expect(
-        Transaction(testPayments)
-            .toSummaryMessage(datetime: DateTime(2000, 1, 23, 16, 56))
-            .title,
-        equals("Settlements on 1/23/2000 16:56"),
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('ja'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(context: context)
+                    .title
+                    .startsWith("精算概要 ["),
+                equals(true),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
       );
     });
 
-    test(
+    testWidgets(
+        'toSummaryMessage_英語でも日本語でもない設定の時、title属性がSettlements summary [から始まる英語文字列である',
+        (WidgetTester tester) async {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('kn'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(context: context)
+                    .title
+                    .startsWith("Settlements summary ["),
+                equals(true),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('toSummaryMessage_英語設定の時、title属性が英語圏向け順番のyMd Hm形式の文字列である',
+        (WidgetTester tester) async {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(
+                      datetime: DateTime(2000, 1, 23, 16, 56),
+                      context: context,
+                    )
+                    .title,
+                equals("Settlements summary [ 1/23/2000 16:56 ]"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('toSummaryMessage_日本語設定の時、title属性が日本語圏向け順番のyMd Hm形式の文字列である',
+        (WidgetTester tester) async {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('ja'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(
+                      datetime: DateTime(2000, 1, 23, 16, 56),
+                      context: context,
+                    )
+                    .title,
+                equals("精算概要 [ 2000/1/23 16:56 ]"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('toSummaryMessage_スペイン語設定の時、title属性がスペイン語圏向け順番のyMd Hm形式の文字列である',
+        (WidgetTester tester) async {
+      final List<Payment> testPayments = [
+        Payment(
+          title: "testPaymentA",
+          payer: testParticipant1,
+          price: 6000,
+          owners: {
+            testParticipant1: true,
+            testParticipant2: true,
+            testParticipant3: true
+          },
+        ),
+      ];
+
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('es'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(
+                      datetime: DateTime(2000, 1, 23, 16, 56),
+                      context: context,
+                    )
+                    .title,
+                equals("Settlements summary [ 23/1/2000 16:56 ]"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets(
         'toSummaryMessage_1件のPaymentを与えている時、body属性が支払、立替、精算の順に改行2つで繋がったメッセージを返す',
-        () {
+        (WidgetTester tester) async {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -235,29 +441,47 @@ void main() {
         ),
       ];
 
-      expect(
-        Transaction(testPayments).toSummaryMessage().body,
-        equals(
-          [
-            '[Payments]\n',
-            'testPaymentA(testName1): 6000.0',
-            '\n\n',
-            '[Creditors]\n',
-            'testName1: 4000.0\n',
-            'testName2: -2000.0\n',
-            'testName3: -2000.0',
-            '\n\n',
-            '[Settlement]\n',
-            'testName2 -> testName1: 2000.0\n',
-            'testName3 -> testName1: 2000.0'
-          ].join(),
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(context: context)
+                    .body,
+                equals(
+                  [
+                    '[Payments]\n',
+                    'testPaymentA(testName1): 6000.0',
+                    '\n\n',
+                    '[Creditors]\n',
+                    'testName1: 4000.0\n',
+                    'testName2: -2000.0\n',
+                    'testName3: -2000.0',
+                    '\n\n',
+                    '[Settlement]\n',
+                    'testName2 -> testName1: 2000.0\n',
+                    'testName3 -> testName1: 2000.0'
+                  ].join(),
+                ),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
       );
     });
 
-    test(
+    testWidgets(
         'toSummaryMessage_2件以上のPaymentを与えている時、body属性が支払、立替、精算の順に改行2つで繋がったメッセージを返す',
-        () {
+        (WidgetTester tester) async {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -291,29 +515,48 @@ void main() {
         )
       ];
 
-      expect(
-        Transaction(testPayments).toSummaryMessage().body,
-        equals(
-          [
-            '[Payments]\n',
-            'testPaymentA(testName1): 6000.0\n',
-            'testPaymentB(testName2): 900.0\n',
-            'testPaymentC(testName3): 30000.0',
-            '\n\n',
-            '[Creditors]\n',
-            'testName1: -6000.0\n',
-            'testName2: -11550.0\n',
-            'testName3: 17550.0',
-            '\n\n',
-            '[Settlement]\n',
-            'testName1 -> testName3: 6000.0\n',
-            'testName2 -> testName3: 11550.0'
-          ].join(),
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                Transaction(testPayments)
+                    .toSummaryMessage(context: context)
+                    .body,
+                equals(
+                  [
+                    '[Payments]\n',
+                    'testPaymentA(testName1): 6000.0\n',
+                    'testPaymentB(testName2): 900.0\n',
+                    'testPaymentC(testName3): 30000.0',
+                    '\n\n',
+                    '[Creditors]\n',
+                    'testName1: -6000.0\n',
+                    'testName2: -11550.0\n',
+                    'testName3: 17550.0',
+                    '\n\n',
+                    '[Settlement]\n',
+                    'testName1 -> testName3: 6000.0\n',
+                    'testName2 -> testName3: 11550.0'
+                  ].join(),
+                ),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
       );
     });
 
-    test('PaymentsExt_toCreditor_与えたPaymentに基づいた立替を返す', () {
+    testWidgets('PaymentsExt_toCreditor_与えたPaymentに基づいた立替を返す',
+        (WidgetTester tester) async {
       final List<Payment> testPayments = [
         Payment(
           title: "testPaymentA",
@@ -332,14 +575,17 @@ void main() {
       );
     });
 
-    test('PaymentsExt_toSummary_空配列を与えた時、ラベルのみを返す', () {
+    testWidgets('PaymentsExt_toSummary_空配列を与えた時、ラベルのみを返す',
+        (WidgetTester tester) async {
       expect(
-        <Payment>[].toSummary(),
+        <Payment>[].toSummary("Payments"),
         equals("[Payments]"),
       );
     });
 
-    test('PaymentsExt_toSummary_1件の支払いを与えた時、ラベルに加えて支払名と支払者と金額を改行1つで繋げて返す', () {
+    testWidgets(
+        'PaymentsExt_toSummary_1件の支払いを与えた時、ラベルに加えて支払名と支払者と金額を改行1つで繋げて返す',
+        (WidgetTester tester) async {
       expect(
         [
           Payment(
@@ -352,12 +598,13 @@ void main() {
               testParticipant3: true,
             },
           )
-        ].toSummary(),
+        ].toSummary("Payments"),
         equals("[Payments]\ntestPaymentA(testName1): 20.0"),
       );
     });
 
-    test('PaymentsExt_toSummary_2件以上の支払いを与えた時、全ての支払いが含まれた値を改行1つで繋げて返す', () {
+    testWidgets('PaymentsExt_toSummary_2件以上の支払いを与えた時、全ての支払いが含まれた値を改行1つで繋げて返す',
+        (WidgetTester tester) async {
       expect(
         [
           Payment(
@@ -390,7 +637,7 @@ void main() {
               testParticipant3: true,
             },
           )
-        ].toSummary(),
+        ].toSummary("Payments"),
         equals(
           "[Payments]\ntestPaymentA(testName1): 20.0\ntestPaymentB(testName2): 300.0\ntestPaymentC(testName3): 4000.0",
         ),

--- a/test/ui/core/double_ext_test.dart
+++ b/test/ui/core/double_ext_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
+import 'package:tatetsu/ui/core/double_ext.dart';
+
+void main() {
+  testWidgets('DoubleExt_toHintText_英語設定の時、元の値に対して、例示であることがわかる英語接頭辞が付与された有理数を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect(666.0.toHintText(context), equals("e.g. 666.0"));
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+  });
+
+  testWidgets(
+      'DoubleExt_toHintText_日本語設定の時、元の値に対して、例示であることがわかる日本語接頭辞が付与された整数を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('ja'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect(19980.0.toHintText(context), equals("例. 19980"));
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+  });
+
+  testWidgets('DoubleExt_toHintText_英語でも日本語でもない設定の時、元の値に対して、例示であることがわかる英語接頭辞が付与された有理数を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('kn'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect(19980.0.toHintText(context), equals("e.g. 19980.0"));
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+  });
+}

--- a/test/ui/core/string_ext_test.dart
+++ b/test/ui/core/string_ext_test.dart
@@ -1,11 +1,65 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
-import 'package:test/test.dart';
 
 void main() {
-  test('StringExt_toHintText_元の値に対して、例示であることがわかる接頭辞が付与された値を返す', () {
-    expect(
-      'testname1'.toHintText(),
-      'e.g. testname1',
+  testWidgets('StringExt_toHintText_英語設定の時、元の値に対して、例示であることがわかる英語接頭辞が付与された値を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('en'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect("西川".toHintText(context), equals("e.g. 西川"));
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+  });
+
+  testWidgets(
+      'StringExt_toHintText_日本語設定の時、元の値に対して、例示であることがわかる日本語接頭辞が付与された値を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('ja'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect("西川".toHintText(context), equals("例. 西川"));
+            return const Placeholder();
+          },
+        ),
+      ),
+    );
+  });
+
+  testWidgets('StringExt_toHintText_英語でも日本語でもない設定の時、元の値に対して、英語接頭辞が付与された値を返す',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Localizations(
+        delegates: const [
+          AppLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+        ],
+        locale: const Locale('kn'),
+        child: Builder(
+          builder: (BuildContext context) {
+            expect("西川".toHintText(context), equals("e.g. 西川"));
+            return const Placeholder();
+          },
+        ),
+      ),
     );
   });
 }

--- a/test/ui/input_accounting_detail/payment_component_test.dart
+++ b/test/ui/input_accounting_detail/payment_component_test.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
-import 'package:test/test.dart';
 
 void main() {
   final Participant testParticipant1 = Participant("testName1");
@@ -34,13 +37,78 @@ void main() {
       );
     });
 
-    test('PaymentComponent_sample_owners属性に、title属性に、ユーザーが想像しやすいような名前が設定される',
-        () {
-      expect(
-        PaymentComponent.sample(
-          participants: [testParticipant1, testParticipant2],
-        ).title,
-        equals("Lunch at the nice cafe"),
+    testWidgets('PaymentComponent_sample_英語設定の時、title属性に英語の値が設定される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                PaymentComponent.sample(
+                  participants: [testParticipant1, testParticipant2],
+                  context: context,
+                ).title,
+                equals("Lunch at the nice cafe"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('PaymentComponent_sample_日本語設定の時、title属性に日本語の値が設定される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('ja'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                PaymentComponent.sample(
+                  participants: [testParticipant1, testParticipant2],
+                  context: context,
+                ).title,
+                equals("昼食代"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
+      );
+    });
+
+    testWidgets('PaymentComponent_sample_英語でも日本語でもない設定の時、title属性に英語の値が設定される',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('es'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                PaymentComponent.sample(
+                  participants: [testParticipant1, testParticipant2],
+                  context: context,
+                ).title,
+                equals("Lunch at the nice cafe"),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
       );
     });
 
@@ -63,89 +131,218 @@ void main() {
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つでプロパティがサンプルと同じ時true',
-        () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..title = "Lunch at the nice cafe"
-            ..payer = testParticipant1
-            ..price = 66.0
-            ..owners = {testParticipant1: true, testParticipant2: true}
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets(
+        'PaymentComponentsExt_hasOnlySampleElement_要素数が1つでプロパティがサンプルと同じ時true',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )
+                    ..title = "Lunch at the nice cafe"
+                    ..payer = testParticipant1
+                    ..price = 66.0
+                    ..owners = {testParticipant1: true, testParticipant2: true}
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                true,
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        true,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払名が異なる時false', () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..title = "modified title"
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets(
+        'PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払名が異なる時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )..title = "modified title"
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払者が異なる時false', () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..payer = testParticipant2
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets(
+        'PaymentComponentsExt_hasOnlySampleElement_要素数が1つで支払者が異なる時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )..payer = testParticipant2
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで価格が異なる時false', () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..price = 0.01
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで価格が異なる時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )..price = 0.01
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つで精算対象者が異なる時false',
-        () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-            ..owners = {testParticipant1: true, testParticipant2: false}
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets(
+        'PaymentComponentsExt_hasOnlySampleElement_要素数が1つで精算対象者が異なる時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )..owners = {testParticipant1: true, testParticipant2: false}
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        false,
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が1つだが参加者が異なる時false', () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-        ].hasOnlySampleElement(onParticipants: [testParticipant1]),
-        false,
+    testWidgets(
+        'PaymentComponentsExt_hasOnlySampleElement_要素数が1つだが参加者が異なる時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
+        ),
       );
     });
 
-    test('PaymentComponentsExt_hasOnlySampleElement_要素数が2以上の時false', () {
-      expect(
-        [
-          PaymentComponent(participants: [testParticipant1, testParticipant2]),
-          PaymentComponent(participants: [testParticipant1, testParticipant2])
-        ].hasOnlySampleElement(
-          onParticipants: [testParticipant1, testParticipant2],
+    testWidgets('PaymentComponentsExt_hasOnlySampleElement_要素数が2以上の時false',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Localizations(
+          delegates: const [
+            AppLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+          ],
+          locale: const Locale('en'),
+          child: Builder(
+            builder: (BuildContext context) {
+              expect(
+                [
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  ),
+                  PaymentComponent(
+                    participants: [testParticipant1, testParticipant2],
+                  )
+                ].hasOnlySampleElement(
+                  onParticipants: [testParticipant1, testParticipant2],
+                  context: context,
+                ),
+                equals(false),
+              );
+              return const Placeholder();
+            },
+          ),
         ),
-        false,
       );
     });
   });


### PR DESCRIPTION
## 概要

このプロダクトコード内で収まる部分をまず日本語化

## 変更内容詳細

### 立替参加者入力画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183768-2c2f949e-b5cf-421b-ae78-9163641d35e9.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183604-941655f0-4285-4cd0-9834-50afe8c00d14.png">

### 会計入力画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183800-0d0f5d70-1dc4-48a3-a982-77644f4c70aa.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183629-d96954c1-b339-4777-9da3-79e743f53d6a.png">

### 精算結果画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183832-e9af3179-22d2-43e9-8667-f88adba2365b.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183665-264ad879-be4c-4b7d-b624-f58ea137f519.png">

### 共有メッセージ

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183876-f2ded99d-938d-450f-aad1-f3f028cdb204.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/155183696-f3115fe9-ec4a-40e3-9eef-45c55ff74efe.png">

## 参考

### Localization利用ウィジェットに対してのテスト

https://qiita.com/kasa_le/items/036131ac2dc97b226f13