### PR TITLE
aabをアップロードした際にPlayStoreより指摘された警告に対応

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,6 +62,7 @@ android {
 
     buildTypes {
         release {
+            ndk.debugSymbolLevel "full"
             signingConfig signingConfigs.release
         }
     }


### PR DESCRIPTION
## 概要

SSIA

## 変更内容詳細

公式通りにやってもエラーしたので、エラーメッセージに従い文字列を直接指定した

https://developer.android.com/studio/build/shrink-code#native-crash-support