### PR TITLE
画面デザイン調整諸々

### DIFF
--- a/lib/config/core.dart
+++ b/lib/config/core.dart
@@ -15,3 +15,5 @@ const MaterialColor tatetsuViolet = MaterialColor(
     900: Color(0xFF54598E),
   },
 );
+
+const Color tatetsuGrey = Color(0xFFBDBDBD); // materialのDropDownの下線の色から持ってきた色

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_flavor/flutter_flavor.dart';
+import 'package:tatetsu/config/core.dart';
 
 void setConfig() => FlavorConfig(
       name: "name",
       variables: {
         "application_title": "title",
         "application_theme": ThemeData(
-          primarySwatch: Colors.red,
+          colorScheme: const ColorScheme.light(
+            primary: Colors.red,
+            onSurface: tatetsuGrey,
+          ),
+          primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         "entry_page_title_prefix": "[Env]",

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -13,6 +13,7 @@ void setConfig() => FlavorConfig(
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           hintColor: tatetsuGrey,
+          useMaterial3: true,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         "entry_page_title_prefix": "[Env]",

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -12,6 +12,7 @@ void setConfig() => FlavorConfig(
             onSurface: tatetsuGrey,
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
+          hintColor: tatetsuGrey,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         "entry_page_title_prefix": "[Env]",

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -131,10 +131,10 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
           onPressed: hasOnlyParticipants
               ? null
               : () => {_removeParticipant(participantIndex)},
-          child: const Icon(
+          child: Icon(
             Icons.person_remove,
             size: 32,
-            color: Colors.grey,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
         ),
       ],

--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import 'package:share_plus/share_plus.dart';
@@ -42,8 +44,10 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
                     widget.transaction.toSummaryMessage(context: context);
                 Share.share(summaryMessage.body, subject: summaryMessage.title);
               },
-              child: const Icon(
-                Icons.share,
+              child: Icon(
+                (Platform.isMacOS || Platform.isIOS)
+                    ? Icons.ios_share
+                    : Icons.share,
                 size: 32,
               ),
             )


### PR DESCRIPTION
## 概要

スクショ作成に先んじた、デザインの調整

- 無効状態ボタン色のコントラスト調整
- 入力域hintの色のコントラスト調整
- Apple専用共有アイコン

## 変更内容詳細

### 会計明細入力画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/156908959-b76c0e16-9a96-45d7-9d2d-ef427142647e.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/156909008-dd9f83ab-ed08-4eb2-b959-4760a17f813e.png">


### 参加者入力画面

変更前|変更後
---|---
<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/156908946-a2c59395-25bf-49f0-bc4d-2ef4137622a2.png">|<img width="476" alt="image" src="https://user-images.githubusercontent.com/38374045/156909064-42f01984-1754-49ae-adb7-6794785d6a0e.png">

## TODO

デバイス状態注入、広告状態と合わせて複雑になってきたのでリファクタリングしてよさそう。

## 参考

下記が参考になった

### iOS/Androidの分岐

https://stackoverflow.com/questions/45924474/how-do-you-detect-the-host-platform-from-dart-code