### PR TITLE
非活性ボタンやヒントの色をより濃い灰色に変更

### DIFF
--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -9,7 +9,7 @@ void setConfig() => FlavorConfig(
         "application_theme": ThemeData(
           colorScheme: const ColorScheme.light(
             primary: Colors.red,
-            onSurface: tatetsuGrey,
+            onSurface: tatetsuGrey, // これを設定しないと、非活性状態アイコンと入力域下線の基準色にデフォルト値黒が設定され、アプリテーマカラーの他アイコンとのコントラストが低くなってしまう
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           hintColor: tatetsuGrey,

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -13,6 +13,7 @@ void setConfig() => FlavorConfig(
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           hintColor: tatetsuGrey,
+          disabledColor: tatetsuGrey, // これを設定しないと、編集破棄ダイアログキャンセル文字色にデフォルト値濃いめ灰色が設定され、アプリテーマカラーの破棄ボタンとのコントラストが低くなってしまう
           useMaterial3: true,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -9,7 +9,7 @@ void setConfig() => FlavorConfig(
         "application_theme": ThemeData(
           colorScheme: const ColorScheme.light(
             primary: Colors.red,
-            onSurface: tatetsuGrey, // これを設定しないと、非活性状態アイコンと入力域下線の基準色にデフォルト値黒が設定され、アプリテーマカラーの他アイコンとのコントラストが低くなってしまう
+            onSurface: Colors.grey, // これを設定しないと、非活性状態アイコンと入力域下線の基準色にデフォルト値黒が設定され、アプリテーマカラーの他アイコンとのコントラストが低くなってしまう
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           hintColor: tatetsuGrey,

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -12,7 +12,6 @@ void setConfig() => FlavorConfig(
             onSurface: Colors.grey, // これを設定しないと、非活性状態アイコンと入力域下線の基準色にデフォルト値黒が設定され、アプリテーマカラーの他アイコンとのコントラストが低くなってしまう
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
-          hintColor: tatetsuGrey,
           disabledColor: tatetsuGrey, // これを設定しないと、編集破棄ダイアログキャンセル文字色にデフォルト値濃いめ灰色が設定され、アプリテーマカラーの破棄ボタンとのコントラストが低くなってしまう
           useMaterial3: true,
           visualDensity: VisualDensity.adaptivePlatformDensity,


### PR DESCRIPTION
## 概要

スクショを作っていて、流石に文字色が薄いなと思ったため修正。

## 変更内容詳細

### 参加者入力画面

変更前|変更後
---|---
<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161407000-cf5849f3-cfa2-422d-b75e-db9d4b604e32.png">|<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161406925-9c2d34d3-1913-47d9-b833-1e1fdcc12d81.png">

### 会計入力画面

変更前|変更後
---|---
<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161407005-940cf91c-9fb7-4c9d-ad82-62ca4a2e021d.png">|<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161406941-57d7d441-2f37-456d-901c-18c17a473200.png">

### 会計破棄ダイアログ

変更前|変更後
---|---
<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161407010-17fa37db-eb2d-4add-84d1-3c59505817c3.png">|<img width="477" alt="image" src="https://user-images.githubusercontent.com/38374045/161406963-034c90a5-13af-459c-a884-cf9921b53bc2.png">
