### PR TITLE
fastlane precheckのエラーに対応

### DIFF
--- a/fastlane/metadata/copyright.txt
+++ b/fastlane/metadata/copyright.txt
@@ -1,1 +1,1 @@
-Tetsuya Nishikawa
+Tetsuya Nishikawa, 2022

--- a/fastlane/metadata/en-US/support_url.txt
+++ b/fastlane/metadata/en-US/support_url.txt
@@ -1,1 +1,1 @@
-https://tatetsu.firebaseapp.com
+https://tatetsu.ntetz.com

--- a/fastlane/metadata/ja/support_url.txt
+++ b/fastlane/metadata/ja/support_url.txt
@@ -1,1 +1,1 @@
-https://tatetsu.firebaseapp.com
+https://tatetsu.ntetz.com


### PR DESCRIPTION
## 概要

Apple側ストアアップロードを試していたら、審査提出前に動く precheck で警告が出ていたのを見つけたので対応。

## 変更内容詳細

下記エラーに言われた通りに対応

<img width="626" alt="image" src="https://user-images.githubusercontent.com/38374045/163708607-45051d93-ebb8-46db-8618-68c7de1dbf1a.png">

## 動作確認

本内容が入った下記ビルドで、当該警告が発生しないことを確認。

https://dev.azure.com/tetphi1dev/tatetsu/_build/results?buildId=1323&view=results

## 参考

https://docs.fastlane.tools/actions/precheck/