### PR TITLE
iPadでシェアボタン押下時にダイアログが出現しなかった事象を修正

### DIFF
--- a/lib/ui/settle_accounts/settle_accounts_page.dart
+++ b/lib/ui/settle_accounts/settle_accounts_page.dart
@@ -42,7 +42,13 @@ class _SettleAccountsPageState extends State<SettleAccountsPage> {
               onPressed: () {
                 final summaryMessage =
                     widget.transaction.toSummaryMessage(context: context);
-                Share.share(summaryMessage.body, subject: summaryMessage.title);
+                final Size size = MediaQuery.of(context).size;
+                Share.share(
+                  summaryMessage.body,
+                  subject: summaryMessage.title,
+                  sharePositionOrigin:
+                      Rect.fromLTWH(0, 0, size.width * 2, size.height / 16),
+                );
               },
               child: Icon(
                 (Platform.isMacOS || Platform.isIOS)


### PR DESCRIPTION
## 概要

審査時に指摘された下記事項に対応

> Specifically, your app Share button was not responsive. Please review the details below and complete the next steps. 

## 変更内容詳細

シェアボタン押下時の差異が下記

変更前|変更後
---|---
<img width="635" alt="image" src="https://user-images.githubusercontent.com/38374045/166130404-38b1d093-8c51-4c29-8274-433114dc9019.png">|<img width="635" alt="image" src="https://user-images.githubusercontent.com/38374045/166130415-d489c23e-2bbf-414a-8e93-7f667a2397da.png">

## 参考

下記が参考になった。

https://github.com/flutter/flutter/issues/47220#issuecomment-608453383