### PR TITLE
ntetz.com配下でFirebase Dynamic Linksを利用できるようにした

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,7 +8,11 @@
     ],
     "rewrites": [
       {
-        "source": "**",
+        "source": "/links/**",
+        "dynamicLinks": true
+      },
+      {
+        "source": "!/links/**",
         "destination": "/index.html"
       }
     ]


### PR DESCRIPTION
## 概要

https://tatetsu.ntetz.com/links/store_ja を使えるようにした。

## 備考

この対応を行わないと、Firebase Dynamic Linksでドメインを設定しようとした際、下記エラーが出てしまう。

```
It looks like you already have content served on this path. Specify a different path prefix to avoid conflicts with existing content.
```

## 参考

https://firebase.google.com/docs/dynamic-links/custom-domains#manual
https://stackoverflow.com/questions/55174935/unable-to-add-firebase-dynamic-links-to-a-project-using-a-custom-domain