### PR TITLE
画面遷移が遷移前画面の状態に依存しないようリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ lib/config/prd.dart
 android/app/src/*/res/*/ic_launcher.png
 ios/Runner/Assets.xcassets/AppIcon-*.appiconset/
 
+# flutter build_runner
+*.g.dart
+
 # Firebase
 android/app/src/*/google-services.json
 ios/Firebase/GoogleService-Info-*.plist

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,12 @@ stages:
     - script: |
         echo '>> $FLUTTERTOOLPATH/flutter pub get'
         $FLUTTERTOOLPATH/flutter pub get
+      displayName: 'Install Build Tools (scratch)'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter pub run build_runner build'
+        $FLUTTERTOOLPATH/flutter pub run build_runner build
+      displayName: 'Build Dto (scratch)'
+    - script: |
         echo '>> $FLUTTERTOOLPATH/flutter analyze'
         $FLUTTERTOOLPATH/flutter analyze
       displayName: 'Flutter Analyze (scratch)'
@@ -89,6 +95,10 @@ stages:
         echo '>> $FLUTTERTOOLPATH/flutter pub get'
         $FLUTTERTOOLPATH/flutter pub get
       displayName: 'Install Build Tools (scratch)'
+    - script: |
+        echo '>> $FLUTTERTOOLPATH/flutter pub run build_runner build'
+        $FLUTTERTOOLPATH/flutter pub run build_runner build
+      displayName: 'Build Dto (scratch)'
     - script: |
         echo '>> $FLUTTERTOOLPATH/flutter pub run flutter_launcher_icons:main'
         $FLUTTERTOOLPATH/flutter pub run flutter_launcher_icons:main
@@ -182,6 +192,10 @@ stages:
             echo '>> $FLUTTERTOOLPATH/flutter pub get'
             $FLUTTERTOOLPATH/flutter pub get
           displayName: 'Install Build Tools (scratch)'
+        - script: |
+            echo '>> $FLUTTERTOOLPATH/flutter pub run build_runner build'
+            $FLUTTERTOOLPATH/flutter pub run build_runner build
+          displayName: 'Build Dto (scratch)'
         - script: |
             echo '>> $FLUTTERTOOLPATH/flutter pub run flutter_launcher_icons:main'
             $FLUTTERTOOLPATH/flutter pub run flutter_launcher_icons:main

--- a/lib/model/core/build_context_ext.dart
+++ b/lib/model/core/build_context_ext.dart
@@ -1,0 +1,20 @@
+import 'dart:convert';
+
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+import 'package:tatetsu/model/transport/codable.dart';
+
+extension ContextExt on BuildContext {
+  void goTo({required String path, required Codable params}) {
+    go(
+      Uri(
+        path: path,
+        queryParameters: {
+          "params": json.encode(
+            params.toJson(),
+          )
+        },
+      ).toString(),
+    );
+  }
+}

--- a/lib/model/transport/account_detail_dto.dart
+++ b/lib/model/transport/account_detail_dto.dart
@@ -1,10 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:tatetsu/model/transport/codable.dart';
 import 'package:tatetsu/model/transport/payment_dto.dart';
 
 part 'account_detail_dto.g.dart';
 
 @JsonSerializable()
-class AccountDetailDto {
+class AccountDetailDto implements Codable {
   AccountDetailDto({required this.pNm, required this.ps});
 
   final List<String> pNm;
@@ -13,5 +14,6 @@ class AccountDetailDto {
   factory AccountDetailDto.fromJson(Map<String, dynamic> json) =>
       _$AccountDetailDtoFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$AccountDetailDtoToJson(this);
 }

--- a/lib/model/transport/account_detail_dto.dart
+++ b/lib/model/transport/account_detail_dto.dart
@@ -1,0 +1,17 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
+
+part 'account_detail_dto.g.dart';
+
+@JsonSerializable()
+class AccountDetailDto {
+  AccountDetailDto({required this.pNm, required this.ps});
+
+  final List<String> pNm;
+  final List<PaymentDto> ps;
+
+  factory AccountDetailDto.fromJson(Map<String, dynamic> json) =>
+      _$AccountDetailDtoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$AccountDetailDtoToJson(this);
+}

--- a/lib/model/transport/codable.dart
+++ b/lib/model/transport/codable.dart
@@ -1,0 +1,3 @@
+class Codable {
+  Map<String, dynamic> toJson() => throw UnimplementedError();
+}

--- a/lib/model/transport/payment_dto.dart
+++ b/lib/model/transport/payment_dto.dart
@@ -1,9 +1,11 @@
 import 'package:json_annotation/json_annotation.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+import 'package:tatetsu/model/transport/codable.dart';
 
 part 'payment_dto.g.dart';
 
 @JsonSerializable()
-class PaymentDto {
+class PaymentDto implements Codable {
   final String ttl;
   final String pN;
   final double prc;
@@ -16,8 +18,16 @@ class PaymentDto {
     required this.ons,
   });
 
+  PaymentDto.fromPayment(Payment payment)
+      : ttl = payment.title,
+        pN = payment.payer.displayName,
+        prc = payment.price,
+        ons = payment.owners
+            .map((key, value) => MapEntry(key.displayName, value));
+
   factory PaymentDto.fromJson(Map<String, dynamic> json) =>
       _$PaymentDtoFromJson(json);
 
+  @override
   Map<String, dynamic> toJson() => _$PaymentDtoToJson(this);
 }

--- a/lib/model/transport/payment_dto.dart
+++ b/lib/model/transport/payment_dto.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'payment_dto.g.dart';
+
+@JsonSerializable()
+class PaymentDto {
+  final String ttl;
+  final String pN;
+  final double prc;
+  final Map<String, bool> ons;
+
+  PaymentDto({
+    required this.ttl,
+    required this.pN,
+    required this.prc,
+    required this.ons,
+  });
+
+  factory PaymentDto.fromJson(Map<String, dynamic> json) =>
+      _$PaymentDtoFromJson(json);
+
+  Map<String, dynamic> toJson() => _$PaymentDtoToJson(this);
+}

--- a/lib/tatetsu.dart
+++ b/lib/tatetsu.dart
@@ -5,6 +5,7 @@ import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
+import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class Tatetsu extends StatelessWidget {
   @override
@@ -27,6 +28,16 @@ class Tatetsu extends StatelessWidget {
                 key: state.pageKey,
                 child: const InputAccountingDetailPage(),
               ),
+              routes: [
+                GoRoute(
+                  path: "settle_accounts",
+                  pageBuilder: (BuildContext context, GoRouterState state) =>
+                      MaterialPage(
+                    key: state.pageKey,
+                    child: const SettleAccountsPage(),
+                  ),
+                ),
+              ],
             )
           ],
         ),

--- a/lib/tatetsu.dart
+++ b/lib/tatetsu.dart
@@ -1,23 +1,49 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tatetsu/config/application_meta.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
+import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
 import 'package:tatetsu/ui/input_participants/input_participants_page.dart';
 
 class Tatetsu extends StatelessWidget {
   @override
-  Widget build(BuildContext context) => MaterialApp(
-        localizationsDelegates: const [
-          AppLocalizations.delegate,
-          GlobalMaterialLocalizations.delegate,
-          GlobalWidgetsLocalizations.delegate,
-          GlobalCupertinoLocalizations.delegate,
-        ],
-        supportedLocales: const [Locale('en', ''), Locale('ja', '')],
-        title: getAppTitle(),
-        theme: getAppTheme(),
-        home: InputParticipantsPage(
-          titlePrefix: getEntryPageTitlePrefix(),
+  Widget build(BuildContext context) {
+    final _router = GoRouter(
+      routes: [
+        GoRoute(
+          path: "/",
+          pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: InputParticipantsPage(
+              titlePrefix: getEntryPageTitlePrefix(),
+            ),
+          ),
+          routes: [
+            GoRoute(
+              path: "accounting_detail",
+              pageBuilder: (BuildContext context, GoRouterState state) =>
+                  MaterialPage(
+                key: state.pageKey,
+                child: const InputAccountingDetailPage(),
+              ),
+            )
+          ],
         ),
-      );
+      ],
+    );
+
+    return MaterialApp.router(
+      routerConfig: _router,
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en', ''), Locale('ja', '')],
+      title: getAppTitle(),
+      theme: getAppTheme(),
+    );
+  }
 }

--- a/lib/ui/input_accounting_detail/accounting_detail_state.dart
+++ b/lib/ui/input_accounting_detail/accounting_detail_state.dart
@@ -1,0 +1,35 @@
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
+import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
+
+class AccountingDetailState {
+  final List<Participant> participants;
+  final List<PaymentComponent> payments;
+
+  AccountingDetailState({required this.participants, required this.payments});
+}
+
+extension AccountDetailDtoExt on AccountDetailDto {
+  AccountingDetailState toAccountingDetailState() {
+    final participants = pNm.map((e) => Participant(e)).toList();
+    final payments = ps
+        .map(
+          (e) => PaymentComponent.of(
+            title: e.ttl,
+            payer: participants.firstWhere((p) => p.displayName == e.pN),
+            price: e.prc,
+            owners: e.ons.map(
+              (ownerString, value) => MapEntry(
+                participants.firstWhere((p) => p.displayName == ownerString),
+                value,
+              ),
+            ),
+          ),
+        )
+        .toList();
+    return AccountingDetailState(
+      participants: participants,
+      payments: payments,
+    );
+  }
+}

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,22 +1,22 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
 import 'package:tatetsu/ui/core/double_ext.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
+import 'package:tatetsu/ui/input_accounting_detail/accounting_detail_state.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
-  const InputAccountingDetailPage({
-    required this.participants,
-    required this.payments,
-  }) : super();
+  const InputAccountingDetailPage({required this.params}) : super();
 
-  final List<Participant> participants;
-  final List<PaymentComponent> payments;
+  final Map<String, String> params;
 
   @override
   _InputAccountingDetailPageState createState() =>
@@ -24,8 +24,12 @@ class InputAccountingDetailPage extends StatefulWidget {
 }
 
 class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
+  AccountingDetailState? state;
+
   @override
   Widget build(BuildContext context) {
+    _initializeStateIfEmpty(widget.params);
+
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
       child: WillPopScope(
@@ -68,19 +72,20 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
                 key: UniqueKey(),
                 expansionCallback: (int index, bool isExpanded) {
                   setState(() {
-                    widget.payments[index].isExpanded = !isExpanded;
+                    state?.payments[index].isExpanded = !isExpanded;
                   });
                 },
-                children: widget.payments
-                    .map<ExpansionPanel>((PaymentComponent payment) {
-                  return ExpansionPanel(
-                    headerBuilder: (BuildContext _, bool __) {
-                      return _paymentHeader(payment);
-                    },
-                    body: _paymentBody(payment),
-                    isExpanded: payment.isExpanded,
-                  );
-                }).toList(),
+                children: state?.payments
+                        .map<ExpansionPanel>((PaymentComponent payment) {
+                      return ExpansionPanel(
+                        headerBuilder: (BuildContext _, bool __) {
+                          return _paymentHeader(payment);
+                        },
+                        body: _paymentBody(payment),
+                        isExpanded: payment.isExpanded,
+                      );
+                    }).toList() ??
+                    [],
               );
             },
             itemCount: 2, // 入力部分と追加ボタンで、合計2
@@ -90,11 +95,30 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     );
   }
 
+  void _initializeStateIfEmpty(Map<String, String> params) {
+    final paramsValue = params["params"];
+    if (paramsValue == null) return;
+
+    state ??= AccountDetailDto.fromJson(
+      jsonDecode(paramsValue) as Map<String, dynamic>,
+    ).toAccountingDetailState();
+
+    if (state?.payments.isEmpty ?? false) {
+      state?.payments.add(
+        PaymentComponent.sample(
+          participants: state?.participants ?? [],
+          context: context,
+        ),
+      );
+    }
+  }
+
   Future<bool> _showDiscardConfirmDialogIfNeeded() =>
-      widget.payments.hasOnlySampleElement(
-        onParticipants: widget.participants,
-        context: context,
-      )
+      state?.payments.hasOnlySampleElement(
+                onParticipants: state?.participants ?? [],
+                context: context,
+              ) ??
+              false
           ? Future(() => true)
           : showDialog<bool>(
               context: context,
@@ -130,7 +154,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       MaterialPageRoute(
         builder: (BuildContext context) {
           return SettleAccountsPage(
-            payments: widget.payments.map((e) => e.toPayment()).toList(),
+            payments: state?.payments.map((e) => e.toPayment()).toList() ?? [],
             advertisementUsecase: AdvertisementUsecase.shared(),
           );
         },
@@ -140,9 +164,9 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
 
   void _insertPaymentToLast() {
     setState(() {
-      widget.payments.add(
+      state?.payments.add(
         PaymentComponent(
-          participants: widget.participants,
+          participants: state?.participants ?? [],
           context: context,
         ),
       );
@@ -151,7 +175,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
 
   void _deletePayment(PaymentComponent payment) {
     setState(() {
-      widget.payments.remove(payment);
+      state?.payments.remove(payment);
     });
   }
 
@@ -248,7 +272,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
   }
 
   List<Widget> _actionsView(PaymentComponent payment) {
-    final bool isOnlyPayment = widget.payments.length <= 1;
+    final bool isOnlyPayment = (state?.payments.length ?? 0) <= 1;
     return [
       const SizedBox(height: 16),
       Row(

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
@@ -14,9 +15,7 @@ import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
-  const InputAccountingDetailPage({required this.params}) : super();
-
-  final Map<String, String> params;
+  const InputAccountingDetailPage() : super();
 
   @override
   _InputAccountingDetailPageState createState() =>
@@ -28,7 +27,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
 
   @override
   Widget build(BuildContext context) {
-    _initializeStateIfEmpty(widget.params);
+    _initializeStateIfEmpty(context);
 
     return GestureDetector(
       onTap: () => FocusManager.instance.primaryFocus?.unfocus(),
@@ -95,8 +94,8 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
     );
   }
 
-  void _initializeStateIfEmpty(Map<String, String> params) {
-    final paramsValue = params["params"];
+  void _initializeStateIfEmpty(BuildContext context) {
+    final paramsValue = GoRouterState.of(context).queryParams["params"];
     if (paramsValue == null) return;
 
     state ??= AccountDetailDto.fromJson(

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -3,16 +3,16 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
+import 'package:tatetsu/model/core/build_context_ext.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/transport/account_detail_dto.dart';
-import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
 import 'package:tatetsu/ui/core/double_ext.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/accounting_detail_state.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
-import 'package:tatetsu/ui/settle_accounts/settle_accounts_page.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
   const InputAccountingDetailPage() : super();
@@ -149,14 +149,14 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
       );
 
   void _toSettleAccounts() {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (BuildContext context) {
-          return SettleAccountsPage(
-            payments: state?.payments.map((e) => e.toPayment()).toList() ?? [],
-            advertisementUsecase: AdvertisementUsecase.shared(),
-          );
-        },
+    context.goTo(
+      path: "/accounting_detail/settle_accounts",
+      params: AccountDetailDto(
+        pNm: state?.participants.map((e) => e.displayName).toList() ?? [],
+        ps: state?.payments
+                .map((e) => PaymentDto.fromPayment(e.toPayment()))
+                .toList() ??
+            [],
       ),
     );
   }

--- a/lib/ui/input_accounting_detail/payment_component.dart
+++ b/lib/ui/input_accounting_detail/payment_component.dart
@@ -23,6 +23,13 @@ class PaymentComponent {
         payer = participants.first,
         owners = Map.fromIterables(participants, participants.map((_) => true));
 
+  PaymentComponent.of({
+    required this.title,
+    required this.payer,
+    required this.price,
+    required this.owners,
+  });
+
   PaymentComponent.sample({
     required List<Participant> participants,
     required BuildContext context,

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -1,8 +1,6 @@
-import 'dart:convert';
-
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
+import 'package:tatetsu/model/core/build_context_ext.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/transport/account_detail_dto.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
@@ -92,18 +90,12 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
       );
 
   void _toInputAccounting() {
-    context.go(
-      Uri(
-        path: "/accounting_detail",
-        queryParameters: {
-          "params": json.encode(
-            AccountDetailDto(
-              pNm: _participants.map((e) => e.displayName).toList(),
-              ps: [],
-            ),
-          )
-        },
-      ).toString(),
+    context.goTo(
+      path: "/accounting_detail",
+      params: AccountDetailDto(
+        pNm: _participants.map((e) => e.displayName).toList(),
+        ps: [],
+      ),
     );
   }
 

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -1,10 +1,12 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
-import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 
 class InputParticipantsPage extends StatefulWidget {
   const InputParticipantsPage({required this.titlePrefix}) : super();
@@ -94,13 +96,14 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
       MaterialPageRoute(
         builder: (BuildContext context) {
           return InputAccountingDetailPage(
-            participants: _participants,
-            payments: [
-              PaymentComponent.sample(
-                participants: _participants,
-                context: context,
+            params: {
+              "params": json.encode(
+                AccountDetailDto(
+                  pNm: _participants.map((e) => e.displayName).toList(),
+                  ps: [],
+                ).toJson(),
               )
-            ],
+            },
           );
         },
       ),

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -1,12 +1,12 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/transport/account_detail_dto.dart';
 import 'package:tatetsu/model/usecase/participants_usecase.dart';
 import 'package:tatetsu/ui/core/string_ext.dart';
-import 'package:tatetsu/ui/input_accounting_detail/input_accounting_detail_page.dart';
 
 class InputParticipantsPage extends StatefulWidget {
   const InputParticipantsPage({required this.titlePrefix}) : super();
@@ -92,21 +92,18 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
       );
 
   void _toInputAccounting() {
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (BuildContext context) {
-          return InputAccountingDetailPage(
-            params: {
-              "params": json.encode(
-                AccountDetailDto(
-                  pNm: _participants.map((e) => e.displayName).toList(),
-                  ps: [],
-                ).toJson(),
-              )
-            },
-          );
+    context.go(
+      Uri(
+        path: "/accounting_detail",
+        queryParameters: {
+          "params": json.encode(
+            AccountDetailDto(
+              pNm: _participants.map((e) => e.displayName).toList(),
+              ps: [],
+            ),
+          )
         },
-      ),
+      ).toString(),
     );
   }
 

--- a/lib/ui/settle_accounts/settle_accounts_state.dart
+++ b/lib/ui/settle_accounts/settle_accounts_state.dart
@@ -1,0 +1,35 @@
+import 'package:tatetsu/model/entity/participant.dart';
+import 'package:tatetsu/model/entity/payment.dart';
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
+
+class SettleAccountsState {
+  SettleAccountsState({
+    required this.payments,
+  });
+
+  final List<Payment> payments;
+}
+
+extension AccountDetailDtoExt on AccountDetailDto {
+  SettleAccountsState toSettleAccountsState() {
+    final participants = pNm.map((e) => Participant(e)).toList();
+    final payments = ps
+        .map(
+          (e) => Payment(
+            title: e.ttl,
+            payer: participants.firstWhere((p) => p.displayName == e.pN),
+            price: e.prc,
+            owners: e.ons.map(
+              (ownerString, value) => MapEntry(
+                participants.firstWhere((p) => p.displayName == ownerString),
+                value,
+              ),
+            ),
+          ),
+        )
+        .toList();
+    return SettleAccountsState(
+      payments: payments,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -308,6 +308,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  go_router:
+    dependency: "direct main"
+    description:
+      name: go_router
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.0"
   google_mobile_ads:
     dependency: "direct main"
     description:
@@ -770,4 +777,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.17.0 <3.0.0"
-  flutter: ">=2.5.0"
+  flutter: ">=3.3.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,62 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.1"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.1"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
+  build_resolvers:
+    dependency: transitive
+    description:
+      name: build_resolvers
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.10"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.0"
+  build_runner_core:
+    dependency: transitive
+    description:
+      name: build_runner_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.7"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.4.2"
   characters:
     dependency: transitive
     description:
@@ -57,6 +113,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
   clock:
     dependency: transitive
     description:
@@ -64,6 +127,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.4.0"
   collection:
     dependency: "direct main"
     description:
@@ -99,6 +169,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
+  dart_style:
+    dependency: transitive
+    description:
+      name: dart_style
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.4"
   english_words:
     dependency: "direct main"
     description:
@@ -176,6 +253,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.13"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -231,6 +315,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -280,6 +371,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.4"
+  json_annotation:
+    dependency: "direct main"
+    description:
+      name: json_annotation
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.7.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.5.4"
   lint:
     dependency: "direct dev"
     description:
@@ -371,6 +476,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.1"
   share_plus:
     dependency: "direct main"
     description:
@@ -446,6 +558,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.99"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.6"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.3"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -478,6 +604,13 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
@@ -516,6 +649,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.16"
+  timing:
+    dependency: transitive
+    description:
+      name: timing
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,12 +23,15 @@ dependencies:
   google_mobile_ads: ^1.1.0
   intl: ^0.17.0
   japanese_family_name_generator: ^0.0.1
+  json_annotation: ^4.7.0
   share_plus: ^3.0.4
 
 dev_dependencies:
+  build_runner: ^2.0.0
   flutter_launcher_icons: ^0.9.2
   flutter_test:
     sdk: flutter
+  json_serializable: ^6.5.4
   lint:
   test:
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_flavor: ^3.0.3
   flutter_localizations:
     sdk: flutter
+  go_router: ^6.0.0
   google_mobile_ads: ^1.1.0
   intl: ^0.17.0
   japanese_family_name_generator: ^0.0.1

--- a/test/model/transport/account_detail_dto_test.dart
+++ b/test/model/transport/account_detail_dto_test.dart
@@ -1,0 +1,235 @@
+import 'dart:convert';
+
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccountDetailDto', () {
+    test('toJson_全属性が空の時、全属性が空', () {
+      expect(
+        AccountDetailDto(pNm: [], ps: []).toJson(),
+        {"pNm": [], "ps": []},
+      );
+    });
+
+    test('toJson_参加者1人の時、pNmに対象の参加者1名が含まれている', () {
+      expect(
+        AccountDetailDto(pNm: ["suzuki"], ps: []).toJson(),
+        {
+          "pNm": ["suzuki"],
+          "ps": []
+        },
+      );
+    });
+
+    test('toJson_参加者2人の時、pNmに対象の参加者2名が含まれている', () {
+      expect(
+        AccountDetailDto(pNm: ["suzuki", "tanaka"], ps: []).toJson(),
+        {
+          "pNm": ["suzuki", "tanaka"],
+          "ps": []
+        },
+      );
+    });
+
+    test('toJson_参加者3人の時、pNmに対象の参加者3名が含まれている', () {
+      expect(
+        AccountDetailDto(pNm: ["suzuki", "tanaka", "sato"], ps: []).toJson(),
+        {
+          "pNm": ["suzuki", "tanaka", "sato"],
+          "ps": []
+        },
+      );
+    });
+
+    test('toJson_会計1つの時、psに対象の会計1件が含まれている', () {
+      expect(
+          jsonDecode(
+            jsonEncode(
+              AccountDetailDto(
+                pNm: ["suzuki", "tanaka", "sato"],
+                ps: [
+                  PaymentDto(
+                    ttl: "会計タイトル",
+                    pN: "sato",
+                    prc: 49800,
+                    ons: {"suzuki": true, "tanaka": true, "sato": true},
+                  )
+                ],
+              ).toJson(),
+            ),
+          ) as Map<String, dynamic>,
+          {
+            "pNm": ["suzuki", "tanaka", "sato"],
+            "ps": [
+              {
+                "ttl": "会計タイトル",
+                "pN": "sato",
+                "prc": 49800,
+                "ons": {"suzuki": true, "tanaka": true, "sato": true}
+              }
+            ]
+          });
+    });
+
+    test('toJson_会計2つの時、psに対象の会計2件が含まれている', () {
+      expect(
+          jsonDecode(
+            jsonEncode(
+              AccountDetailDto(
+                pNm: ["suzuki", "tanaka", "sato"],
+                ps: [
+                  PaymentDto(
+                    ttl: "会計タイトル",
+                    pN: "sato",
+                    prc: 49800,
+                    ons: {"suzuki": true, "tanaka": true, "sato": true},
+                  ),
+                  PaymentDto(
+                    ttl: "会計タイトル2",
+                    pN: "tanaka",
+                    prc: 7980,
+                    ons: {"suzuki": true, "tanaka": false, "sato": true},
+                  )
+                ],
+              ).toJson(),
+            ),
+          ) as Map<String, dynamic>,
+          {
+            "pNm": ["suzuki", "tanaka", "sato"],
+            "ps": [
+              {
+                "ttl": "会計タイトル",
+                "pN": "sato",
+                "prc": 49800,
+                "ons": {"suzuki": true, "tanaka": true, "sato": true}
+              },
+              {
+                "ttl": "会計タイトル2",
+                "pN": "tanaka",
+                "prc": 7980,
+                "ons": {"suzuki": true, "tanaka": false, "sato": true}
+              }
+            ]
+          });
+    });
+
+    test('toJson_支払い参加者と支払い対象者が異なる不正な会計も変換される', () {
+      expect(
+          jsonDecode(
+            jsonEncode(
+              AccountDetailDto(
+                pNm: ["imai", "nakagawa"],
+                ps: [
+                  PaymentDto(
+                    ttl: "会計タイトル",
+                    pN: "sato",
+                    prc: 49800,
+                    ons: {"takano": true, "nakagi": true, "yamao": true},
+                  )
+                ],
+              ).toJson(),
+            ),
+          ) as Map<String, dynamic>,
+          {
+            "pNm": ["imai", "nakagawa"],
+            "ps": [
+              {
+                "ttl": "会計タイトル",
+                "pN": "sato",
+                "prc": 49800,
+                "ons": {"takano": true, "nakagi": true, "yamao": true}
+              }
+            ]
+          });
+    });
+
+    test('fromJson_参加者1人の時、pNmに対象の参加者1名が含まれている', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["suzuki"],
+          "ps": []
+        }).pNm,
+        ["suzuki"],
+      );
+    });
+
+    test('fromJson_参加者2人の時、pNmに対象の参加者2名が含まれている', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["suzuki", "tanaka"],
+          "ps": []
+        }).pNm,
+        ["suzuki", "tanaka"],
+      );
+    });
+
+    test('fromJson_参加者3人の時、pNmに対象の参加者3名が含まれている', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["suzuki", "tanaka", "sato"],
+          "ps": []
+        }).pNm,
+        ["suzuki", "tanaka", "sato"],
+      );
+    });
+
+    test('fromJson_会計1つの時、psに対象の会計1件が含まれている', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["suzuki", "tanaka", "sato"],
+          "ps": [
+            {
+              "ttl": "会計タイトル1",
+              "pN": "sato",
+              "prc": 47800,
+              "ons": {"suzuki": true, "tanaka": true, "sato": true}
+            }
+          ]
+        }).ps[0].ttl,
+        "会計タイトル1",
+      );
+    });
+
+    test('fromJson_会計2つの時、psに対象の会計が含まれている', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["suzuki", "tanaka", "sato"],
+          "ps": [
+            {
+              "ttl": "会計タイトル1",
+              "pN": "sato",
+              "prc": 47800,
+              "ons": {"suzuki": true, "tanaka": true, "sato": true}
+            },
+            {
+              "ttl": "会計タイトル2",
+              "pN": "tanaka",
+              "prc": 7980,
+              "ons": {"suzuki": true, "tanaka": true, "sato": true}
+            }
+          ]
+        }).ps[1].ttl,
+        "会計タイトル2",
+      );
+    });
+
+    test('fromJson_支払い参加者と支払い対象者が異なる不正な会計も変換される', () {
+      expect(
+        AccountDetailDto.fromJson({
+          "pNm": ["imai", "nakagawa"],
+          "ps": [
+            {
+              "ttl": "会計タイトル",
+              "pN": "sato",
+              "prc": 47800,
+              "ons": {"takano": true, "nakagi": true, "yamao": true},
+            }
+          ]
+        }).ps[0].ttl,
+        "会計タイトル",
+      );
+    });
+  });
+}

--- a/test/model/transport/payment_dto_test.dart
+++ b/test/model/transport/payment_dto_test.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+
+import 'package:tatetsu/model/transport/payment_dto.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PaymentDto', () {
+    test('toJson_属性名を維持したまま値が格納される', () {
+      expect(
+        jsonDecode(
+          jsonEncode(
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "suzuki",
+              prc: 76800,
+              ons: {"suzuki": true, "yamamoto": true, "sato": true},
+            ),
+          ),
+        ) as Map<String, dynamic>,
+        {
+          "ttl": "会計タイトル",
+          "pN": "suzuki",
+          "prc": 76800,
+          "ons": {"suzuki": true, "yamamoto": true, "sato": true}
+        },
+      );
+    });
+
+    test('fromJson_属性名を維持したまま値が格納される', () {
+      expect(
+        PaymentDto.fromJson({
+          "ttl": "会計タイトル",
+          "pN": "suzuki",
+          "prc": 76800,
+          "ons": {"suzuki": true, "yamamoto": true, "sato": true}
+        }).ttl,
+        "会計タイトル",
+      );
+    });
+  });
+}

--- a/test/ui/input_accounting_detail/accounting_detail_state_test.dart
+++ b/test/ui/input_accounting_detail/accounting_detail_state_test.dart
@@ -1,0 +1,151 @@
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
+import 'package:tatetsu/ui/input_accounting_detail/accounting_detail_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AccountingDetailState', () {
+    test('toAccountingDetailState_title属性にttl属性の値がそのまま設定される', () {
+      expect(
+        AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toAccountingDetailState().payments[0].title,
+        "会計タイトル",
+      );
+    });
+
+    test(
+        'toAccountingDetailState_payer属性に、ps.pn属性がpNm属性内に一致するものが存在する時、pNm属性に対応したインスタンスが設定される',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true, "sato": true},
+          )
+        ],
+      ).toAccountingDetailState();
+      expect(
+        testState.payments[0].payer,
+        testState.participants[2],
+      );
+    });
+
+    test('toAccountingDetailState_payer属性に関して、ps.pn属性がpNm属性内に一致するものが存在しない時、エラーする',
+        () {
+      expect(
+        () => AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "nakamoto",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toAccountingDetailState(),
+        throwsStateError,
+      );
+    });
+
+    test('toAccountingDetailState_price属性にprc属性の値がそのまま設定される', () {
+      expect(
+        AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toAccountingDetailState().payments[0].price,
+        49800,
+      );
+    });
+
+    test(
+        'toAccountingDetailState_owners属性に、ps.ons属性がpNm属性と一致する時、own属性の値がそのまま設定される',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true, "sato": true},
+          )
+        ],
+      ).toAccountingDetailState();
+
+      expect(
+        testState.payments[0].owners,
+        {
+          testState.participants[0]: true,
+          testState.participants[1]: true,
+          testState.participants[2]: true,
+        },
+      );
+    });
+
+    test(
+        'toAccountingDetailState_owners属性に、ps.ons属性がpNm属性より小さい時、own属性の値がそのまま設定される(エラーはしない仕様)',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true},
+          )
+        ],
+      ).toAccountingDetailState();
+
+      expect(
+        testState.payments[0].owners,
+        {
+          testState.participants[0]: true,
+          testState.participants[1]: true,
+        },
+      );
+    });
+
+    test('toAccountingDetailState_owners属性に関して、ps.ons属性がpNm属性より大きい時、エラーする', () {
+      expect(
+        () => AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {
+                "suzuki": true,
+                "tanaka": true,
+                "sato": true,
+                "murashita": true
+              },
+            )
+          ],
+        ).toAccountingDetailState(),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/test/ui/settle_accounts/settle_accounts_state_test.dart
+++ b/test/ui/settle_accounts/settle_accounts_state_test.dart
@@ -1,0 +1,151 @@
+import 'package:tatetsu/model/transport/account_detail_dto.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
+import 'package:tatetsu/ui/settle_accounts/settle_accounts_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('SettleAccountState', () {
+    test('toSettleAccountState_title属性にttl属性の値がそのまま設定される', () {
+      expect(
+        AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toSettleAccountsState().payments[0].title,
+        "会計タイトル",
+      );
+    });
+
+    test(
+        'toSettleAccountState_payer属性に、ps.pn属性がpNm属性内に一致するものが存在する時、pNm属性に対応したインスタンスが設定される',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true, "sato": true},
+          )
+        ],
+      ).toSettleAccountsState();
+      expect(
+        testState.payments[0].payer,
+        testState.payments[0].owners.keys.toList()[2],
+      );
+    });
+
+    test('toSettleAccountState_payer属性に関して、ps.pn属性がpNm属性内に一致するものが存在しない時、エラーする',
+        () {
+      expect(
+        () => AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "nakamoto",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toSettleAccountsState(),
+        throwsStateError,
+      );
+    });
+
+    test('toSettleAccountState_price属性にprc属性の値がそのまま設定される', () {
+      expect(
+        AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {"suzuki": true, "tanaka": true, "sato": true},
+            )
+          ],
+        ).toSettleAccountsState().payments[0].price,
+        49800,
+      );
+    });
+
+    test(
+        'toSettleAccountState_owners属性に、ps.ons属性がpNm属性と一致する時、own属性の値がそのまま設定される',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true, "sato": true},
+          )
+        ],
+      ).toSettleAccountsState();
+
+      expect(
+        testState.payments[0].owners,
+        {
+          testState.payments[0].owners.keys.toList()[0]: true,
+          testState.payments[0].owners.keys.toList()[1]: true,
+          testState.payments[0].owners.keys.toList()[2]: true,
+        },
+      );
+    });
+
+    test(
+        'toSettleAccountState_owners属性に、ps.ons属性がpNm属性より小さい時、own属性の値がそのまま設定される(エラーはしない仕様)',
+        () {
+      final testState = AccountDetailDto(
+        pNm: ["suzuki", "tanaka", "sato"],
+        ps: [
+          PaymentDto(
+            ttl: "会計タイトル",
+            pN: "sato",
+            prc: 49800,
+            ons: {"suzuki": true, "tanaka": true},
+          )
+        ],
+      ).toSettleAccountsState();
+
+      expect(
+        testState.payments[0].owners,
+        {
+          testState.payments[0].owners.keys.toList()[0]: true,
+          testState.payments[0].owners.keys.toList()[1]: true,
+        },
+      );
+    });
+
+    test('toSettleAccountState_owners属性に関して、ps.ons属性がpNm属性より大きい時、エラーする', () {
+      expect(
+        () => AccountDetailDto(
+          pNm: ["suzuki", "tanaka", "sato"],
+          ps: [
+            PaymentDto(
+              ttl: "会計タイトル",
+              pN: "sato",
+              prc: 49800,
+              ons: {
+                "suzuki": true,
+                "tanaka": true,
+                "sato": true,
+                "murashita": true
+              },
+            )
+          ],
+        ).toSettleAccountsState(),
+        throwsStateError,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 概要

ディープリンクによる会計明細画面直接遷移のための前準備。
GoRouterを利用し画面遷移を宣言的な実装に変え、画面間のデータの受け渡しをjsonの形式にした。

## 参考

下記が大変参考になった。

### jsonのシリアライズ

https://github.com/google/json_serializable.dart/tree/master/example
https://pub.dev/packages/json_annotation
https://qiita.com/kurun_pan/items/455a1e7d6bbd91f0f1f3
https://take4-blue.com/program/flutter-jsonのシリアライズ・デシリアライズ/

### GoRouter

https://pub.dev/documentation/go_router/latest/

### エラーのユニットテスト

https://qiita.com/kasa_le/items/bf48b65fdb8cf1fa0421


