### PR TITLE
会計入力依頼ボタンを追加

### DIFF
--- a/lib/config/core.dart
+++ b/lib/config/core.dart
@@ -16,4 +16,20 @@ const MaterialColor tatetsuViolet = MaterialColor(
   },
 );
 
+const MaterialColor tatetsuVioletLight = MaterialColor(
+  0xFFA1C3E7,
+  {
+    50: Color(0xFFF4F8FC),
+    100: Color(0xFFE3EDF8),
+    200: Color(0xFFD0E1F3),
+    300: Color(0xFFBDD5EE),
+    400: Color(0xFFAFCCEB),
+    500: Color(0xFFA1C3E7),
+    600: Color(0xFF99BDE4),
+    700: Color(0xFF8FB5E0),
+    800: Color(0xFF85AEDD),
+    900: Color(0xFF74A1D7),
+  },
+);
+
 const Color tatetsuGrey = Color(0xFFBDBDBD); // materialのDropDownの下線の色から持ってきた色

--- a/lib/config/sample_env.dart
+++ b/lib/config/sample_env.dart
@@ -9,7 +9,9 @@ void setConfig() => FlavorConfig(
         "application_theme": ThemeData(
           colorScheme: const ColorScheme.light(
             primary: Colors.red,
+            secondary: Colors.pinkAccent,
             onSurface: Colors.grey, // これを設定しないと、非活性状態アイコンと入力域下線の基準色にデフォルト値黒が設定され、アプリテーマカラーの他アイコンとのコントラストが低くなってしまう
+            onSecondary: Colors.white,
           ),
           primarySwatch: Colors.red, // これを設定しないとチェックボックス(立替参加者除外画面)の色にprimaryが設定されない
           disabledColor: tatetsuGrey, // これを設定しないと、編集破棄ダイアログキャンセル文字色にデフォルト値濃いめ灰色が設定され、アプリテーマカラーの破棄ボタンとのコントラストが低くなってしまう

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -79,6 +79,14 @@
   "@paymentDiscardConfirmDialogBody": {
     "description": "payment support dialog body"
   },
+  "requestPaymentAdditionMessageTitlePrefix": "Payment addition request to [ ",
+  "@requestPaymentAdditionMessageTitlePrefix": {
+    "description": "request payment addition message title prefix"
+  },
+  "requestPaymentAdditionMessageTitleSuffix": " ] ...etc",
+  "@requestPaymentAdditionMessageTitleSuffix": {
+    "description": "request payment addition message title suffix"
+  },
   "summaryPaymentsTitle": "Payments",
   "@summaryPaymentsTitle": {
     "description": "summary title"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -19,6 +19,8 @@
   "paymentDeleteConfirmDescriptionPrefix": "会計 [",
   "paymentDeleteConfirmDescriptionSuffix": "] を削除してもよろしいですか?",
   "paymentDiscardConfirmDialogBody": "編集内容を破棄してもよろしいですか？",
+  "requestPaymentAdditionMessageTitlePrefix": "支払入力依頼( ",
+  "requestPaymentAdditionMessageTitleSuffix": " など)",
   "summaryPaymentsTitle": "会計",
   "summaryPaymentsItemLabel": "品目",
   "summaryCreditorsTitle": "立替",

--- a/lib/ui/input_accounting_detail/accounting_detail_state.dart
+++ b/lib/ui/input_accounting_detail/accounting_detail_state.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/transport/account_detail_dto.dart';
+import 'package:tatetsu/model/transport/payment_dto.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 
 class AccountingDetailState {
@@ -7,6 +10,22 @@ class AccountingDetailState {
   final List<PaymentComponent> payments;
 
   AccountingDetailState({required this.participants, required this.payments});
+
+  Uri toUri({required String path}) => Uri(
+        scheme: "https",
+        host: "tatetsu.ntetz.com",
+        path: path,
+        queryParameters: {
+          "params": jsonEncode(
+            AccountDetailDto(
+              pNm: participants.map((e) => e.displayName).toList(),
+              ps: payments
+                  .map((e) => PaymentDto.fromPayment(e.toPayment()))
+                  .toList(),
+            ).toJson(),
+          )
+        },
+      );
 }
 
 extension AccountDetailDtoExt on AccountDetailDto {

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -56,45 +56,35 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
             ],
           ),
           body: ListView.builder(
-            itemBuilder: (BuildContext context, int index) {
-              if (index == 1) {
-                return Center(
-                  child: Wrap(
-                    children: [
-                      TextButton(
-                        onPressed: _insertPaymentToLast,
-                        child: const Icon(Icons.add_circle, size: 32),
-                      )
-                    ],
-                  ),
-                );
-              }
-
-              return ExpansionPanelList(
-                key: UniqueKey(),
-                expansionCallback: (int index, bool isExpanded) {
-                  setState(() {
-                    state?.payments[index].isExpanded = !isExpanded;
-                  });
-                },
-                children: state?.payments
-                        .map<ExpansionPanel>((PaymentComponent payment) {
-                      return ExpansionPanel(
-                        headerBuilder: (BuildContext _, bool __) {
-                          return _paymentHeader(payment);
-                        },
-                        body: _paymentBody(payment),
-                        isExpanded: payment.isExpanded,
-                      );
-                    }).toList() ??
-                    [],
-              );
-            },
-            itemCount: 2, // 入力部分と追加ボタンで、合計2
+            itemBuilder: (BuildContext context, int index) =>
+                ExpansionPanelList(
+              key: UniqueKey(),
+              expansionCallback: (int index, bool isExpanded) {
+                setState(() {
+                  state?.payments[index].isExpanded = !isExpanded;
+                });
+              },
+              children: state?.payments
+                      .map<ExpansionPanel>((PaymentComponent payment) {
+                    return ExpansionPanel(
+                      headerBuilder: (BuildContext _, bool __) {
+                        return _paymentHeader(payment);
+                      },
+                      body: _paymentBody(payment),
+                      isExpanded: payment.isExpanded,
+                    );
+                  }).toList() ??
+                  [],
+            ),
+            itemCount: 1,
           ),
           floatingActionButton: ExpandableFab(
             distance: 128,
             children: [
+              ExpandableFabChildButton(
+                onPressed: _insertPaymentToLast,
+                icon: const Icon(Icons.create, size: 32),
+              ),
               ExpandableFabChildButton(
                 onPressed: _showShareModal,
                 icon: const Icon(

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:tatetsu/l10n/built/app_localizations.dart';
 import 'package:tatetsu/model/core/build_context_ext.dart';
 import 'package:tatetsu/model/core/double_ext.dart';
@@ -13,6 +14,8 @@ import 'package:tatetsu/ui/core/string_ext.dart';
 import 'package:tatetsu/ui/input_accounting_detail/accounting_detail_state.dart';
 import 'package:tatetsu/ui/input_accounting_detail/exclude_participants_dialog.dart';
 import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
+import 'package:tatetsu/ui/util/expandable_fab.dart';
+import 'package:tatetsu/ui/util/expandable_fab_child_button.dart';
 
 class InputAccountingDetailPage extends StatefulWidget {
   const InputAccountingDetailPage() : super();
@@ -88,6 +91,18 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
               );
             },
             itemCount: 2, // 入力部分と追加ボタンで、合計2
+          ),
+          floatingActionButton: ExpandableFab(
+            distance: 128,
+            children: [
+              ExpandableFabChildButton(
+                onPressed: _showShareModal,
+                icon: const Icon(
+                  Icons.shortcut,
+                  size: 32,
+                ),
+              ),
+            ],
           ),
         ),
       ),
@@ -299,6 +314,25 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         ],
       )
     ];
+  }
+
+  void _showShareModal() {
+    final pageUrlText = state
+            ?.toUri(path: GoRouterState.of(context).fullpath ?? "")
+            .toString() ??
+        "";
+    final requestSubject = [
+      AppLocalizations.of(context)?.requestPaymentAdditionMessageTitlePrefix,
+      state?.payments[0].title,
+      AppLocalizations.of(context)?.requestPaymentAdditionMessageTitleSuffix
+    ].join();
+    final size = MediaQuery.of(context).size;
+    Share.share(
+      pageUrlText,
+      subject: requestSubject,
+      sharePositionOrigin:
+          Rect.fromLTWH(0, 0, size.width * 2, size.height / 16),
+    );
   }
 
   AlertDialog _paymentDeleteConfirmDialog(PaymentComponent payment) =>

--- a/lib/ui/util/expandable_fab.dart
+++ b/lib/ui/util/expandable_fab.dart
@@ -1,0 +1,172 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+@immutable
+class ExpandableFab extends StatefulWidget {
+  const ExpandableFab({
+    super.key,
+    this.initialOpen,
+    required this.distance,
+    required this.children,
+  });
+
+  final bool? initialOpen;
+  final double distance;
+  final List<Widget> children;
+
+  @override
+  State<ExpandableFab> createState() => _ExpandableFabState();
+}
+
+class _ExpandableFabState extends State<ExpandableFab>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+  late final Animation<double> _expandAnimation;
+  bool _open = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _open = widget.initialOpen ?? false;
+    _controller = AnimationController(
+      value: _open ? 1.0 : 0.0,
+      duration: const Duration(milliseconds: 250),
+      vsync: this,
+    );
+    _expandAnimation = CurvedAnimation(
+      curve: Curves.fastOutSlowIn,
+      reverseCurve: Curves.easeOutQuad,
+      parent: _controller,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _toggle() {
+    setState(() {
+      _open = !_open;
+      if (_open) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.expand(
+      child: Stack(
+        alignment: Alignment.bottomRight,
+        clipBehavior: Clip.none,
+        children: [
+          _buildTapToCloseFab(),
+          ..._buildExpandingActionButtons(),
+          _buildTapToOpenFab(),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildExpandingActionButtons() =>
+      List.generate(widget.children.length, (n) => n)
+          .map(
+            (i) => _ExpandingActionButton(
+              position: i,
+              maxDistance: widget.distance,
+              progress: _expandAnimation,
+              child: widget.children[i],
+            ),
+          )
+          .toList();
+
+  Widget _buildTapToCloseFab() => SizedBox(
+        width: 56.0,
+        height: 56.0,
+        child: Center(
+          child: Material(
+            shape: const CircleBorder(),
+            clipBehavior: Clip.antiAlias,
+            elevation: 4.0,
+            child: InkWell(
+              onTap: _toggle,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Icon(
+                  Icons.close,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+  Widget _buildTapToOpenFab() => IgnorePointer(
+        ignoring: _open,
+        child: AnimatedContainer(
+          transformAlignment: Alignment.center,
+          transform: Matrix4.diagonal3Values(
+            _open ? 0.7 : 1.0,
+            _open ? 0.7 : 1.0,
+            1.0,
+          ),
+          duration: const Duration(milliseconds: 250),
+          curve: const Interval(0.0, 0.5, curve: Curves.easeOut),
+          child: AnimatedOpacity(
+            opacity: _open ? 0.0 : 1.0,
+            curve: const Interval(0.25, 1.0, curve: Curves.easeInOut),
+            duration: const Duration(milliseconds: 250),
+            child: FloatingActionButton(
+              // この指定がないと、自前のThemeDataを使っているためか、丸型ではなく角丸になってしまう
+              shape: const CircleBorder(),
+              onPressed: _toggle,
+              child: const Icon(Icons.add, size: 32),
+            ),
+          ),
+        ),
+      );
+}
+
+@immutable
+class _ExpandingActionButton extends StatelessWidget {
+  const _ExpandingActionButton({
+    required this.position,
+    required this.maxDistance,
+    required this.progress,
+    required this.child,
+  });
+
+  final int position;
+  final double maxDistance;
+  final Animation<double> progress;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => AnimatedBuilder(
+        animation: progress,
+        builder: (context, child) {
+          final offset = Offset.fromDirection(
+            pi / 2,
+            progress.value * (maxDistance / (position + 1)),
+          );
+          return Positioned(
+            right: 4.0 + offset.dx,
+            bottom: 4.0 + offset.dy,
+            child: Transform.rotate(
+              angle: (1.0 - progress.value) * pi / 2,
+              child: child,
+            ),
+          );
+        },
+        child: FadeTransition(
+          opacity: progress,
+          child: child,
+        ),
+      );
+}

--- a/lib/ui/util/expandable_fab_child_button.dart
+++ b/lib/ui/util/expandable_fab_child_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+@immutable
+class ExpandableFabChildButton extends StatelessWidget {
+  const ExpandableFabChildButton({
+    super.key,
+    this.onPressed,
+    required this.icon,
+  });
+
+  final VoidCallback? onPressed;
+  final Widget icon;
+
+  @override
+  Widget build(BuildContext context) => Material(
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        color: Theme.of(context).colorScheme.secondary,
+        elevation: 4.0,
+        child: IconButton(
+          onPressed: onPressed,
+          icon: icon,
+          color: Theme.of(context).colorScheme.onSecondary,
+        ),
+      );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -776,5 +776,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.3.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/test/ui/input_accounting_detail/accounting_detail_state_test.dart
+++ b/test/ui/input_accounting_detail/accounting_detail_state_test.dart
@@ -1,10 +1,123 @@
+import 'package:tatetsu/model/entity/participant.dart';
 import 'package:tatetsu/model/transport/account_detail_dto.dart';
 import 'package:tatetsu/model/transport/payment_dto.dart';
 import 'package:tatetsu/ui/input_accounting_detail/accounting_detail_state.dart';
+import 'package:tatetsu/ui/input_accounting_detail/payment_component.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final Participant testParticipant1 = Participant("testName1");
+  final Participant testParticipant2 = Participant("testName2");
+
   group('AccountingDetailState', () {
+    test('toUri_全属性が空配列の時、クエリストリングparamに空配列のものが入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [],
+          payments: [],
+        ).toUri(path: "/app/accounting_detail_test").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail_test?params=%7B%22pNm%22%3A%5B%5D%2C%22ps%22%3A%5B%5D%7D",
+      );
+    });
+
+    test('toUri_participants属性が1つの値を含む時、クエリストリングparamに1つの値が入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1],
+          payments: [],
+        ).toUri(path: "/app/accounting_detail_test").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail_test?params=%7B%22pNm%22%3A%5B%22testName1%22%5D%2C%22ps%22%3A%5B%5D%7D",
+      );
+    });
+
+    test('toUri_participants属性が複数個の値を含む時、クエリストリングparamに複数個の値が入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1, testParticipant2],
+          payments: [],
+        ).toUri(path: "/app/accounting_detail_test").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail_test?params=%7B%22pNm%22%3A%5B%22testName1%22%2C%22testName2%22%5D%2C%22ps%22%3A%5B%5D%7D",
+      );
+    });
+
+    test('toUri_payments属性が1つの値を含む時、クエリストリングparamsに1つの値が入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1, testParticipant2],
+          payments: [
+            PaymentComponent.of(
+              title: "paymentTitle1",
+              payer: testParticipant1,
+              price: 6780,
+              owners: {testParticipant1: true, testParticipant2: true},
+            )
+          ],
+        ).toUri(path: "/app/accounting_detail").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail?params=%7B%22pNm%22%3A%5B%22testName1%22%2C%22testName2%22%5D%2C%22ps%22%3A%5B%7B%22ttl%22%3A%22paymentTitle1%22%2C%22pN%22%3A%22testName1%22%2C%22prc%22%3A6780.0%2C%22ons%22%3A%7B%22testName1%22%3Atrue%2C%22testName2%22%3Atrue%7D%7D%5D%7D",
+      );
+    });
+
+    test('toUri_payments属性が複数の値を含む時、クエリストリングparamsに複数の値が入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1, testParticipant2],
+          payments: [
+            PaymentComponent.of(
+              title: "paymentTitle1",
+              payer: testParticipant1,
+              price: 6780,
+              owners: {testParticipant1: true, testParticipant2: true},
+            ),
+            PaymentComponent.of(
+              title: "paymentTitle123",
+              payer: testParticipant2,
+              price: 9000,
+              owners: {testParticipant1: false, testParticipant2: true},
+            )
+          ],
+        ).toUri(path: "/app/accounting_detail").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail?params=%7B%22pNm%22%3A%5B%22testName1%22%2C%22testName2%22%5D%2C%22ps%22%3A%5B%7B%22ttl%22%3A%22paymentTitle1%22%2C%22pN%22%3A%22testName1%22%2C%22prc%22%3A6780.0%2C%22ons%22%3A%7B%22testName1%22%3Atrue%2C%22testName2%22%3Atrue%7D%7D%2C%7B%22ttl%22%3A%22paymentTitle123%22%2C%22pN%22%3A%22testName2%22%2C%22prc%22%3A9000.0%2C%22ons%22%3A%7B%22testName1%22%3Afalse%2C%22testName2%22%3Atrue%7D%7D%5D%7D",
+      );
+    });
+
+    test('toUri_payments属性が1つの不正な値を含む時、エラーせずクエリストリングparamsに1つの値が入る', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1, testParticipant2],
+          payments: [
+            PaymentComponent.of(
+              title: "paymentTitle1",
+              payer: testParticipant1,
+              price: 6780,
+              owners: {
+                testParticipant1: true,
+                testParticipant2: true,
+                Participant("間違って入ってしまったユーザー"): true
+              },
+            )
+          ],
+        ).toUri(path: "/app/accounting_detail").toString(),
+        "https://tatetsu.ntetz.com/app/accounting_detail?params=%7B%22pNm%22%3A%5B%22testName1%22%2C%22testName2%22%5D%2C%22ps%22%3A%5B%7B%22ttl%22%3A%22paymentTitle1%22%2C%22pN%22%3A%22testName1%22%2C%22prc%22%3A6780.0%2C%22ons%22%3A%7B%22testName1%22%3Atrue%2C%22testName2%22%3Atrue%2C%22%E9%96%93%E9%81%95%E3%81%A3%E3%81%A6%E5%85%A5%E3%81%A3%E3%81%A6%E3%81%97%E3%81%BE%E3%81%A3%E3%81%9F%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%22%3Atrue%7D%7D%5D%7D",
+      );
+    });
+
+    test('toUri_引数pathにスラッシュ1つのパスを渡した時、そのままURLに反映される', () {
+      expect(
+        AccountingDetailState(
+          participants: [testParticipant1, testParticipant2],
+          payments: [
+            PaymentComponent.of(
+              title: "paymentTitle1",
+              payer: testParticipant1,
+              price: 6780,
+              owners: {testParticipant1: true, testParticipant2: true},
+            )
+          ],
+        ).toUri(path: "koredake").toString(),
+        "https://tatetsu.ntetz.com/koredake?params=%7B%22pNm%22%3A%5B%22testName1%22%2C%22testName2%22%5D%2C%22ps%22%3A%5B%7B%22ttl%22%3A%22paymentTitle1%22%2C%22pN%22%3A%22testName1%22%2C%22prc%22%3A6780.0%2C%22ons%22%3A%7B%22testName1%22%3Atrue%2C%22testName2%22%3Atrue%7D%7D%5D%7D",
+      );
+    });
+
     test('toAccountingDetailState_title属性にttl属性の値がそのまま設定される', () {
       expect(
         AccountDetailDto(


### PR DESCRIPTION
## 概要

入力中の会計をURLの形式で共有できる機能を作成した。

## 変更詳細

変更前|変更後
---|---
![before](https://user-images.githubusercontent.com/38374045/211153486-b77d8549-88cf-486c-b6d6-f1ea3e7c9ca6.gif)|![after](https://user-images.githubusercontent.com/38374045/211153492-422a76fe-498c-4ea5-addd-6bcd53882bf3.gif)

## 参考

### フローティングアクションメニュー

- 公式ドキュメント
  - https://docs.flutter.dev/cookbook/effects/expandable-fab
- カスタムテーマを使っている時のFABの形
  - https://www.choge-blog.com/programming/flutterfloatingactionbutton-rounded-rectangle/
- ボタン数を数字の配列に変換
  - https://stackoverflow.com/questions/37798397/create-a-list-from-0-to-n
- マテリアルアイコン
  - https://zenn.dev/tama8021/articles/dbc931e23120bb
  - https://fonts.google.com/icons?selected=Material+Icons&icon.query=forward

### セカンダリカラー

#52 同様、利用している色は、配色アイデア手帖の `朝焼けの富士 - Early Morning` 。
色名は `9 Clear Blue` カラーコードは `#A1C3E7`

Material Colorの計算は下記を利用した

http://mcg.mbitson.com/#!?mcgpalette0=%23a1c3e7

## TODO

- #30 のように、フローティングアクションメニューを閉じる条件を追加しても良いかもしれない
- アイコンだけで意図が伝わるか微妙なので、必要に応じてタイポを入れる
  - https://dev.classmethod.jp/articles/flutter_widget_intro_wrap/