### PR TITLE
apkビルド時に発生したエラーに対応

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -31,7 +31,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     android.ndkVersion "21.4.7075529"
 
     sourceSets {


### PR DESCRIPTION
## 概要

#98 の対応もれ。

## 詳細

Pixel 4のエミュレータ向けにビルドしたら下記エラーが出てしまったのである。

```
One or more plugins require a higher Android SDK version.
Fix this issue by adding the following to <file path>/tatetsu/android/app/build.gradle:
android {
  compileSdkVersion 33
  ...
}
```