### PR TITLE
fix: google_mobile_adsのCocoaPods制約によるSPM競合でCIビルドが失敗する問題を修正

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,10 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   generate: true
+  config:
+    # google_mobile_ads が CocoaPods のみ対応のため、SPM との競合で pod install が失敗する。
+    # google_mobile_ads が SPM に対応したタイミングで本設定を削除すること。
+    enable-swift-package-manager: false
 
 flutter_icons:
   android: true


### PR DESCRIPTION
## Summary

- Flutter 3.44 から Swift Package Manager (SPM) がデフォルト有効になった
- `google_mobile_ads` がまだ CocoaPods のみ対応のため、SPM との競合で `pod install` が失敗し iOS ビルドが通らなくなっていた
- `pubspec.yaml` に `disable-swift-package-manager: true` を追加してプロジェクトレベルで SPM を無効化した
- `google_mobile_ads` が SPM に対応した際はこの設定を削除すること

## Test plan

- [ ] CI の `Flutter build dev ipa` ステップが成功することを確認する
- [ ] CI の `Flutter build prd ipa` ステップが成功することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)