### PR TITLE
fix: Android compileSdk引き上げとFirebase認証のサービスアカウント移行

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.ntetz.flutter.tatetsu"
-    compileSdkVersion 34
+    compileSdkVersion 35
     compileOptions {
         sourceCompatibility = 21
         targetCompatibility = 21

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -148,14 +148,14 @@ stages:
         ls -latr build/ios/ipa/
         echo '>> ls -latr build/app/outputs/flutter-apk'
         ls -latr build/app/outputs/flutter-apk
-        echo '>> npx firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)'
-        npx firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)
-        echo '>> npx firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD --token $(FIREBASE_TOKEN)'
-        npx firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD) --token $(FIREBASE_TOKEN)
-        echo '>> npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)'
-        npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV) --token $(FIREBASE_TOKEN)
-        echo '>> npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD --token $(FIREBASE_TOKEN)'
-        npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD) --token $(FIREBASE_TOKEN)
+        echo '>> GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-dev-bd6064eefd64.json npx firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV)'
+        GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-dev-bd6064eefd64.json npx firebase appdistribution:distribute build/ios/ipa/T-RelDev.ipa --app $(FIREBASE_APP_ID_IOS_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV)
+        echo '>> GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-prd-19b46b1d474e.json npx firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD)'
+        GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-prd-19b46b1d474e.json npx firebase appdistribution:distribute build/ios/ipa/tatetsu.ipa --app $(FIREBASE_APP_ID_IOS_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD)
+        echo '>> GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-dev-bd6064eefd64.json npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV)'
+        GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-dev-bd6064eefd64.json npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-dev-release.apk --app $(FIREBASE_APP_ID_ANDROID_DEV) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_DEV)
+        echo '>> GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-prd-19b46b1d474e.json npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD)'
+        GOOGLE_APPLICATION_CREDENTIALS=app_distribution_sa_tatetsu-prd-19b46b1d474e.json npx firebase appdistribution:distribute build/app/outputs/flutter-apk/app-prd-release.apk --app $(FIREBASE_APP_ID_ANDROID_PRD) --groups $(FIREBASE_BETA_TESTER_GROUP_NAME_PRD)
       displayName: 'Deploy to Firebase App Distribution'
 - stage: store_app_deploy_stage
   displayName: ストアアプリ配布ステージ
@@ -237,8 +237,8 @@ stages:
             npx firebase --version
           displayName: 'Install Firebase tools'
         - script: |
-            echo '>> npx firebase deploy --token $(FIREBASE_TOKEN)'
-            npx firebase deploy --token $(FIREBASE_TOKEN)
+            echo '>> GOOGLE_APPLICATION_CREDENTIALS=firebase_hosting_sa_tatetsu.json npx firebase deploy'
+            GOOGLE_APPLICATION_CREDENTIALS=firebase_hosting_sa_tatetsu.json npx firebase deploy
           displayName: 'Deploy to ntetz.com'
         - script: |
             echo '>> bundle exec fastlane upload_ipa_to_store'


### PR DESCRIPTION
## Summary

- 依存ライブラリが Android API 35 以上を要求するため compileSdkVersion を 34 から 35 に引き上げる
- Firebase CLI の非推奨 --token 認証を廃止し、GOOGLE_APPLICATION_CREDENTIALS によるサービスアカウント認証に移行する（beta_app_deploy_stage・store_app_deploy_stage の全 Firebase コマンド対象）

## Test plan

- [ ] CI の `Flutter build dev apk` ステップが成功することを確認する
- [ ] CI の `Flutter build prd apk` ステップが成功することを確認する
- [ ] `Deploy to Firebase App Distribution` ステップが成功することを確認する（configs.tar.gz に dev/prd サービスアカウント JSON が含まれていること前提）
- [ ] `Deploy to ntetz.com` ステップは `firebase_hosting_sa_tatetsu.json` の configs.tar.gz 追加後に確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)