### PR TITLE
fix: google_mobile_adsのAndroid SDK 36要件に合わせてcompileSdkVersionを引き上げる

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -35,7 +35,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "com.ntetz.flutter.tatetsu"
-    compileSdkVersion 35
+    compileSdkVersion 36
     compileOptions {
         sourceCompatibility = 21
         targetCompatibility = 21


### PR DESCRIPTION
## Summary

- ローカルビルドのログから `google_mobile_ads` が Android SDK 36 以上を要求していることが判明した
- 前回 PR #115 で compileSdkVersion を 34 → 35 に引き上げたが、35 では不足しており apk ビルドが失敗していた
- compileSdkVersion を 35 から 36 に引き上げる

## Test plan

- [ ] CI の `Flutter build dev apk` ステップが成功することを確認する
- [ ] CI の `Flutter build prd apk` ステップが成功することを確認する
- [ ] `Deploy to Firebase App Distribution` ステップが成功することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)