### PR TITLE
chore: Flutter 3.44マイグレーターが要求するAndroid/iOSの設定変更を適用する

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -54,7 +54,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.ntetz.flutter.tatetsu"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug-dev"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -34,6 +35,7 @@
       buildConfiguration = "Debug-dev"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/prd.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/prd.xcscheme
@@ -26,6 +26,7 @@
       buildConfiguration = "Debug-prd"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
@@ -34,6 +35,7 @@
       buildConfiguration = "Debug-prd"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      customLLDBInitFile = "$(SRCROOT)/Flutter/ephemeral/flutter_lldbinit"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"


### PR DESCRIPTION
## 背景

Flutter 3.44.2へのアップグレード（#113）の際、`flutter pub upgrade` 実行によってFlutterマイグレーターがAndroid/iOSのプラットフォームファイルを自動修正した。

これらの変更はDartコード側の修正に集中していた当時のコミットに含まれず、ローカルにunstagedのまま残っていた。ローカルとCI環境の差分として残り続けると調査コストが上がるため、独立したPRとして取り込む。

## 変更内容

- `android/app/build.gradle`: `minSdkVersion` をハードコードの `21` からFlutter SDKの推奨値 `flutter.minSdkVersion` に変更
- `android/gradle.properties`: `android.builtInKotlin=false`、`android.newDsl=false` をマイグレーターに従い追加
- `ios/Runner.xcodeproj/xcshareddata/xcschemes/dev.xcscheme`: `customLLDBInitFile` をデバッグ・プロファイルスキームに追加

## 検証

PR作成前にローカルでqa_stage相当のコマンドを全て実行し、追加の自動差分が発生しないことを確認した。

- `flutter gen-l10n` → 差分なし
- `flutter pub get` → 差分なし
- `flutter pub run build_runner build` → 差分なし
- `flutter pub run flutter_launcher_icons:main` → 差分なし
- `flutter analyze` → No issues found
- `flutter test` → 208 tests passed

*🐈‍⬛ This comment was assisted by Claude (claude-sonnet-4-6) 🾗*