### PR TITLE
fix: GMA SDK 24.0.0でSDK側から削除されたAD_SERVICES_CONFIGをアプリ側manifestからも削除する

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="com.ntetz.flutter.tatetsu">
     <application
         android:name="${applicationName}"
@@ -52,9 +51,5 @@
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="@string/admob_app_id"/>
-        <property
-            android:name="android.adservices.AD_SERVICES_CONFIG"
-            android:resource="@xml/gma_ad_services_config"
-            tools:replace="android:resource" />
     </application>
 </manifest>


### PR DESCRIPTION
## 背景

CIのAndroid APKビルドが以下のエラーで失敗していた。

```
AAPT: error: resource xml/gma_ad_services_config (aka com.ntetz.flutter.tatetsu.dev:xml/gma_ad_services_config) not found.
```

`AndroidManifest.xml` の `android.adservices.AD_SERVICES_CONFIG` プロパティが `@xml/gma_ad_services_config` を参照しているが、このファイルが存在しないことが原因。

## 根本原因

このプロパティは2025/02/02のコミット（`739778a`）で追加された。当時のGMA Android SDKが自身のmanifestに `AD_SERVICES_CONFIG` を持っており、アプリのmanifestとマージコンフリクトが発生していたため、`tools:replace="android:resource"` で上書きする形で回避したものだった。

その後、**GMA Android SDK 24.0.0がアプリとのマージコンフリクト防止のため、このプロパティを自身のmanifestから削除した**。

現在使用中の `google_mobile_ads 7.0.0` はGMA Android SDK 24.9.0に依存しているため、SDKからはこのプロパティが出力されなくなっている。結果としてアプリ側の宣言だけが残り、存在しないリソースファイルを参照してビルドエラーとなっていた。

## 変更内容

- `android/app/src/main/AndroidManifest.xml` から `android.adservices.AD_SERVICES_CONFIG` の `<property>` ブロックを削除
- `tools:replace` のためだけに追加されていた `xmlns:tools` 宣言も合わせて削除

*🐈‍⬛ This comment was assisted by Claude (claude-sonnet-4-6) 🐾*