### PR TITLE
chore: CIでのJetifyTransformのOOMとAndroidビルドツールの廃止予告警告を解消する

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
         targetCompatibility = 21
     }
 
-    android.ndkVersion "27.0.12077973"
+    android.ndkVersion "28.2.13676358"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx4096M
 android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.8.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.10" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
     id "com.google.gms.google-services" version "4.4.2" apply false
 }
 


### PR DESCRIPTION
## Summary

- `org.gradle.jvmargs` を `-Xmx1536M` から `-Xmx4096M` に引き上げ（Flutter engine JAR の JetifyTransform がヒープ不足で CI ビルドに失敗していたため）
- Gradle `8.10.2` → `8.14`
- AGP `8.8.0` → `8.11.1`（AGP 8.11.1 が Gradle 8.13 以上を要求するため連動）
- Kotlin `2.1.10` → `2.2.20`
- NDK `27.0.12077973` → `28.2.13676358`（`jni` プラグインの要求バージョンに合わせる）

## Test plan

- [ ] CI の `Flutter build dev apk` ステップが Gradle 8.14 + AGP 8.11.1 で成功することを確認する
- [ ] CI の `Flutter build prd apk` ステップが成功することを確認する
- [ ] CI の `Flutter build dev ipa` / `Flutter build prd ipa` ステップが成功することを確認する
- [ ] `Deploy to Firebase App Distribution` ステップが成功することを確認する

## 残存する警告（このPRのスコープ外）

- `firebase_analytics` / `share_plus` が KGP（Kotlin Gradle Plugin）を直接適用している警告 → プラグイン側の問題のため別ブランチで対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)