### PR TITLE
fix: 参加者入力・会計明細入力画面でキーボードが消える不具合を修正

### DIFF
--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -63,7 +63,6 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
           body: ListView.builder(
             itemBuilder: (BuildContext context, int index) =>
                 ExpansionPanelList(
-              key: UniqueKey(),
               expansionCallback: (int index, bool isExpanded) {
                 setState(() {
                   state?.payments[index].isExpanded = !isExpanded;
@@ -201,7 +200,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         decoration:
             InputDecoration(hintText: defaultPaymentTitle.toHintText(context)),
         initialValue: payment.hasUserSpecifiedTitle ? payment.title : null,
-        key: UniqueKey(),
+        key: ObjectKey(payment),
         onChanged: (String value) {
           payment.hasUserSpecifiedTitle = true;
           payment.title = value.isNotEmpty ? value : defaultPaymentTitle;
@@ -275,7 +274,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         ),
         initialValue:
             payment.hasUserSpecifiedPrice ? payment.price.toString() : null,
-        key: UniqueKey(),
+        key: ObjectKey(payment),
         onChanged: (String value) {
           payment.hasUserSpecifiedPrice = true;
           payment.price = value.isNotEmpty

--- a/lib/ui/input_participants/input_participants_page.dart
+++ b/lib/ui/input_participants/input_participants_page.dart
@@ -111,7 +111,7 @@ class _InputParticipantsPageState extends State<InputParticipantsPage> {
             decoration: InputDecoration(
               hintText: defaultParticipantName.toHintText(context),
             ),
-            key: UniqueKey(),
+            key: ObjectKey(participant),
             initialValue: participant.hasUserSpecifiedDisplayName
                 ? participant.displayName
                 : null,


### PR DESCRIPTION
## 概要

- 参加者入力画面・会計明細入力画面で、`TextFormField`の`key`に`UniqueKey()`を使っていたことにより、rebuild のたびに TextField が破棄・再生成されてフォーカスが失われ、キーボードが消える不具合を修正
- `UniqueKey()`を`ObjectKey(participant)` / `ObjectKey(payment)`に変更し、同一オブジェクトの TextField が rebuild をまたいで再利用されるよう修正
- 会計明細画面では`ExpansionPanelList`の`UniqueKey()`も削除

## 混入過程

### 2021年6月 (#4) — `UniqueKey()` の導入

**なぜ `UniqueKey()` を入れたか**

Flutter の `ListView` はインデックスベースでウィジェットを管理する。このため、例えば index 1 の参加者を削除すると、Flutter は「index 1 の TextField」をそのまま再利用しようとし、削除前の index 2 の値が index 1 の位置に残り続けるという問題が発生していた（#4）。

`key: UniqueKey()` を付けることで rebuild のたびに新しいキーが生成され、Flutter が常に TextField を作り直すよう強制することで、この問題を回避した。

**なぜこれがバグの元になったか**

`UniqueKey()` は「毎回全部作り直す」という乱暴な手で、`ObjectKey(participant)` は「変わったものだけ作り直す」精密な手だった。`ObjectKey` を使えば同じ問題をより正確に解決でき、今回の不具合も発生しなかった。

当時 `ObjectKey` に辿り着いていれば、今回の不具合は発生しなかった。

### 2022年12月 (#91) — Flutter 3 移行

`input_participants_page.dart`・`input_accounting_detail_page.dart` への直接変更はなし。ただし Flutter 3 以降でフォーカス管理がより厳密になり、潜在的バグが顕在化しやすい状態になった。

Flutter 2.x では、TextField が再生成された後もフォーカスが短時間保持される挙動があったが、Flutter 3.x ではフォーカスロスト時にキーボードを即座に閉じる挙動が厳格化された。

### 2025年1月 (#111) — `WillPopScope` → `PopScope` 移行

`PopScope.canPop` は build 時に評価される property のため、入力のたびに `canPop` を更新する目的で `onChanged` に `setState(() {})` を追加。意図は正当だったが、`UniqueKey()` との組み合わせにより、会計明細画面では「1文字打つたびに rebuild → `UniqueKey()` → TextField 再生成 → フォーカス消失」が毎回発生し、実質的に文字が打てない状態になっていた。

この時点でソフトウェアキーボードを有効にした状態での入力テストを実施していれば検出できた。iOS シミュレータはデフォルトで Mac の物理キーボードを使用するため、ソフトウェアキーボードの挙動テストが漏れやすい。

### 2026年 (#117) — Flutter 3.44 / iOS 16.0 最低バージョン引き上げ

Flutter 3.44 へのアップグレードで iOS 最低バージョンが 16.0 に引き上げられ、キーボードのライフサイクル管理がさらに厳格化。参加者入力画面でも（`setState` なし・`MediaQuery` の rebuild のみでも）キーボードが消える現象が明確に再現するようになった。

## テスト方針

キーボード表示・フォーカス維持の挙動はウィジェットテストでの自動担保が困難なため、シミュレータ（ソフトウェアキーボード有効: `Cmd + Shift + K`）での手動確認を実施。

- [x] 参加者入力画面：フィールドタップ後、キーボードが表示されたまま維持される
- [x] 参加者入力画面：参加者の追加・削除後も他フィールドの入力内容が維持される
- [x] 会計明細入力画面：タイトル・金額フィールドで連続入力できる
- [x] 会計明細入力画面：会計の追加・削除後も他フィールドの入力内容が維持される
- [x] `flutter analyze` 通過
- [x] `flutter test` 208件通過

## 関連

- #4 — `UniqueKey()` を導入したPR（参加者削除時のTextField値更新バグの修正）
- #91 — Flutter 3 移行PR（iOS最低バージョン 9.0 → 11.0）
- #111 — ライブラリ更新PR（`WillPopScope` → `PopScope` 移行・`setState(() {})` 追加）
- #117 — Flutter 3.44 移行PR（iOS最低バージョン → 16.0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)