### PR TITLE
chore: google_mobile_ads の SPM 未対応による iOS ビルド警告を解消する

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -66,11 +66,11 @@ PODS:
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
   - Flutter (1.0.0)
-  - Google-Mobile-Ads-SDK (12.14.0):
+  - Google-Mobile-Ads-SDK (13.3.0):
     - GoogleUserMessagingPlatform (>= 1.1)
-  - google_mobile_ads (7.0.0):
+  - google_mobile_ads (9.0.0):
     - Flutter
-    - Google-Mobile-Ads-SDK (~> 12.14.0)
+    - Google-Mobile-Ads-SDK (~> 13.3.0)
     - webview_flutter_wkwebview
   - GoogleAdsOnDeviceConversion (3.6.0):
     - GoogleUtilities/Environment (~> 8.1)
@@ -204,8 +204,8 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 7e3d57ce4b1e958bb1d15403faa7178f46bbb5b7
   FirebaseSessions: acfe7eadca47cda94ac86592737204581bb1abf6
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  Google-Mobile-Ads-SDK: 4534fd2dfcd3f705c5485a6633c5188d03d4eed2
-  google_mobile_ads: 2ba32ffef4a026aa94f526774a40a14ca9662adf
+  Google-Mobile-Ads-SDK: 7692126a35ed859f20635af281c50a2162be8bea
+  google_mobile_ads: e0c300fcd472c3fa5a00d6cca8b0c65bbbb15faf
   GoogleAdsOnDeviceConversion: 80ce443fa1b4b5750913d53a04ecda644ff57744
   GoogleAppMeasurement: a6d37949071d456e9147dac6789c4342e0e7a8c5
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -377,10 +377,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_mobile_ads
-      sha256: f35e040875bb54e8a3455bcffed3b4ac9e9263fbf7751b9fd1ae7f30793faee8
+      sha256: "6029f6c48bc9b6b47767ddbb4847683048a2f006d418c871bd93c5eb6a8e5c3c"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "9.0.0"
   graphs:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
   go_router: ^17.0.1
-  google_mobile_ads: ^7.0.0
+  google_mobile_ads: ^9.0.0
   intl: ^0.20.2
   japanese_family_name_generator: ^0.0.1
   json_annotation: ^4.7.0
@@ -39,10 +39,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   generate: true
-  config:
-    # google_mobile_ads が CocoaPods のみ対応のため、SPM との競合で pod install が失敗する。
-    # google_mobile_ads が SPM に対応したタイミングで本設定を削除すること。
-    enable-swift-package-manager: false
 
 flutter_icons:
   android: true


### PR DESCRIPTION
## Summary
- `google_mobile_ads` を `^7.0.0` → `^9.0.0` にアップグレード
- 8.0.0 から Swift Package Manager 対応が追加されたため、CocoaPods を強制する `enable-swift-package-manager: false` 設定を削除
- iOS ビルド時に表示されていた SPM 未対応の警告が解消される

## Test plan
- [ ] `flutter analyze` → No issues found
- [ ] `flutter test` → 208 tests passed
- [ ] iOS ビルドで SPM 未対応警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)