### PR TITLE
fix: 会計明細画面での複数のクラッシュを修正する

### DIFF
--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -2,12 +2,14 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:tatetsu/config/dev.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
+import 'package:tatetsu/model/usecase/crashlytics_usecase.dart';
 import 'package:tatetsu/tatetsu.dart';
 
-void main() {
+void main() async {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
+  await Firebase.initializeApp();
+  CrashlyticsUsecase.shared().initialize();
   AdvertisementUsecase.shared().initialize();
-  Firebase.initializeApp();
   runApp(Tatetsu());
 }

--- a/lib/main_prd.dart
+++ b/lib/main_prd.dart
@@ -2,12 +2,14 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:tatetsu/config/prd.dart';
 import 'package:tatetsu/model/usecase/advertisement_usecase.dart';
+import 'package:tatetsu/model/usecase/crashlytics_usecase.dart';
 import 'package:tatetsu/tatetsu.dart';
 
-void main() {
+void main() async {
   setConfig();
   WidgetsFlutterBinding.ensureInitialized(); // この処理を行わないとAdMobの初期化がうまくいかない
+  await Firebase.initializeApp();
+  CrashlyticsUsecase.shared().initialize();
   AdvertisementUsecase.shared().initialize();
-  Firebase.initializeApp();
   runApp(Tatetsu());
 }

--- a/lib/model/usecase/crashlytics_usecase.dart
+++ b/lib/model/usecase/crashlytics_usecase.dart
@@ -1,0 +1,21 @@
+import 'dart:ui';
+
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/material.dart';
+
+class CrashlyticsUsecase {
+  static final CrashlyticsUsecase _singleton =
+      CrashlyticsUsecase._internal();
+
+  factory CrashlyticsUsecase.shared() => _singleton;
+
+  CrashlyticsUsecase._internal();
+
+  void initialize() {
+    FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+    PlatformDispatcher.instance.onError = (error, stack) {
+      FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+      return true;
+    };
+  }
+}

--- a/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
+++ b/lib/ui/input_accounting_detail/exclude_participants_dialog.dart
@@ -31,21 +31,28 @@ class _ExcludeParticipantsDialogState extends State<ExcludeParticipantsDialog> {
         ],
       );
 
-  Column _checkBoxComponent() => Column(
-        children: widget.payment.owners.entries
-            .map(
-              (e) => Row(
+  Column _checkBoxComponent() {
+    final int checkedCount =
+        widget.payment.owners.values.where((v) => v).length;
+    return Column(
+      children: widget.payment.owners.entries
+          .map(
+            (e) {
+              final bool isLastChecked = e.value && checkedCount == 1;
+              return Row(
                 children: [
                   Checkbox(
                     value: e.value,
-                    onChanged: (bool? value) {
-                      setState(() {
-                        if (value == null) {
-                          return;
-                        }
-                        widget.payment.owners[e.key] = value;
-                      });
-                    },
+                    onChanged: isLastChecked
+                        ? null
+                        : (bool? value) {
+                            setState(() {
+                              if (value == null) {
+                                return;
+                              }
+                              widget.payment.owners[e.key] = value;
+                            });
+                          },
                   ),
                   Expanded(
                     child: Text(
@@ -55,8 +62,10 @@ class _ExcludeParticipantsDialogState extends State<ExcludeParticipantsDialog> {
                     ),
                   ),
                 ],
-              ),
-            )
-            .toList(),
-      );
+              );
+            },
+          )
+          .toList(),
+    );
+  }
 }

--- a/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
+++ b/lib/ui/input_accounting_detail/input_accounting_detail_page.dart
@@ -278,7 +278,7 @@ class _InputAccountingDetailPageState extends State<InputAccountingDetailPage> {
         onChanged: (String value) {
           payment.hasUserSpecifiedPrice = true;
           payment.price = value.isNotEmpty
-              ? double.parse(value).roundAtSecondDecimal()
+              ? (double.tryParse(value) ?? 0).roundAtSecondDecimal()
               : defaultPaymentPriceValue;
           setState(() {});
         },

--- a/test/model/usecase/crashlytics_usecase_test.dart
+++ b/test/model/usecase/crashlytics_usecase_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tatetsu/model/usecase/crashlytics_usecase.dart';
+
+void main() {
+  group('CrashlyticsUsecase', () {
+    test('shared_複数回呼び出した時、同一インスタンスを返す', () {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      expect(
+        CrashlyticsUsecase.shared(),
+        same(CrashlyticsUsecase.shared()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 変更仕様

### 参加者除外ダイアログ（`ExcludeParticipantsDialog`）

| | 修正前 | 修正後 |
|---|---|---|
| 全員チェック外し | 可能 | 不可（最後の1人のチェックボックスは非活性） |

### 金額入力欄（`InputAccountingDetailPage`）

| | 修正前 | 修正後 |
|---|---|---|
| 金額欄に数値以外の文字列をペーストした場合 | クラッシュ | 金額が 0 として扱われる |

### Crashlytics 連携（`CrashlyticsUsecase` / `main`）

| | 修正前 | 修正後 |
|---|---|---|
| Flutter/Dart の未捕捉例外 | Crashlytics に届かない | fatal エラーとして記録される |
| Firebase 初期化 | await なし（完了前に runApp の可能性） | await で完了を待ってから起動 |

## 混入過程

### 参加者除外ダイアログのクラッシュ

`ExcludeParticipantsDialog` に「全員除外を禁止する」制約が設けられていなかったことが、
クラッシュの遠因となっている可能性がある。
`NoDebtorsException` 自体はモデル層のテストで想定されていたが、
UI 層でのガードが漏れていたとみられる。

ユーザーレビューを通じて顕在化。

### 金額入力欄のクラッシュ

`input_accounting_detail_page.dart` に `double.parse` を使った実装時から、
`FormatException` が未捕捉のまま残っていたとみられる。