### PR TITLE
docs: Claude Code 向けプロジェクト設定を追加する

### DIFF
--- a/.claude/commands/upgrade-flutter-native-pkg.md
+++ b/.claude/commands/upgrade-flutter-native-pkg.md
@@ -1,0 +1,65 @@
+# /upgrade-flutter-native-pkg — Upgrade a Flutter package with native (CocoaPods) dependencies
+
+Upgrades a Flutter package that has CocoaPods native dependencies,
+ensuring `pubspec.yaml`, `pubspec.lock`, and `ios/Podfile.lock` are all consistent before committing.
+
+## Steps
+
+### Step 1: Identify the target package and version
+
+Confirm the package and target version with the user, then update `pubspec.yaml`.
+
+```bash
+flutter pub outdated
+```
+
+### Step 2: Resolve Dart dependencies
+
+```bash
+flutter pub get
+flutter analyze
+flutter test
+```
+
+All must pass. If any fail, report to the user and wait for instructions.
+
+### Step 3: Identify and update the CocoaPods dependency
+
+Find the Pod name from the plugin's podspec.
+
+```bash
+cat ios/.symlinks/plugins/<package-name>/ios/*.podspec | grep "s.name"
+```
+
+Update the identified Pod (prepend rbenv shims to PATH if using rbenv).
+
+```bash
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" && eval "$(rbenv init -)"
+cd ios && pod update <PodName>
+```
+
+### Step 4: Verify the iOS build
+
+Build for device using the project's entry point and flavor.
+
+```bash
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" && eval "$(rbenv init -)"
+flutter build ios --no-codesign -t lib/main_dev.dart --flavor dev
+```
+
+- Confirm the build succeeds and the target warning/error is resolved.
+- Confirm `ios/Podfile.lock` is updated via `git status`.
+
+### Step 5: Commit
+
+Stage `pubspec.yaml`, `pubspec.lock`, and `ios/Podfile.lock` together.
+If folding into an existing commit, use rebase (confirm with the user first).
+
+Suggested commit message format:
+
+```
+chore: update iOS Pod dependency for <package-name> <old-version> → <new-version>
+
+Update <PodName> from <old-pod-version> to <new-pod-version> to satisfy
+the requirements of <package-name> <new-version>.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -217,3 +217,6 @@ ios/AdMob/AdMob-prd.xcconfig
 
 # Firebase Hosting
 .firebase
+
+# Claude Code
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# tatetsu
+
+Bill-splitting Flutter app (iOS / Android / Web).
+
+## Tech stack
+
+- Flutter stable (Dart SDK >=3.10.1 <4.0.0)
+- Firebase (Analytics, Crashlytics, Core, App Distribution, Hosting)
+- go_router, google_mobile_ads, flutter_flavor
+- json_annotation + json_serializable (build_runner)
+- flutter_localizations + intl (ARB-based i18n)
+- lint
+
+## Source layout
+
+| Directory | Role |
+|---|---|
+| `lib/config/` | App config; env values injected via flutter_flavor |
+| `lib/l10n/` | ARB files; `built/` is generated — do not edit |
+| `lib/model/core/` | Core domain logic |
+| `lib/model/entity/` | Domain entities (Participant, Payment, Transaction, …) |
+| `lib/model/transport/` | DTOs (`@JsonSerializable`); `*.g.dart` are generated |
+| `lib/model/usecase/` | Use cases |
+| `lib/ui/core/` | Shared UI components |
+| `lib/ui/<screen>/` | One directory per screen |
+| `lib/ui/util/` | UI utilities |
+| `test/` | Mirrors `lib/` layout |
+
+## Flavors
+
+| Entry point | Flavor |
+|---|---|
+| `lib/main_dev.dart` | dev |
+| `lib/main_prd.dart` | prd |
+
+## Architecture decisions
+
+- `main_dev.dart` and `main_prd.dart` must remain thin entry points. Do not write external library implementations (Firebase, AdMob, etc.) directly in them. Limit initialization to `XxxUsecase.shared().initialize()` calls; keep implementation details in `model/usecase/`.
+
+## Build sequence
+
+```sh
+flutter gen-l10n                        # generate l10n
+flutter pub get
+flutter pub run build_runner build      # generate *.g.dart
+flutter analyze                         # must pass
+flutter test
+```
+
+## Do not edit — generated files
+
+- `lib/l10n/built/` — `flutter gen-l10n` output
+- `lib/model/transport/*.g.dart` — `build_runner` output
+
+## Environment
+
+`lib/config/env.dart` is not tracked. Copy `lib/config/sample_env.dart`
+to `lib/config/env.dart` and fill in real values before building.
+
+## Known workaround
+
+`enable-swift-package-manager: false` in `pubspec.yaml`: `google_mobile_ads`
+does not yet support SPM and conflicts with CocoaPods. Remove when resolved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ flutter test
 `lib/config/env.dart` is not tracked. Copy `lib/config/sample_env.dart`
 to `lib/config/env.dart` and fill in real values before building.
 
-## Known workaround
+## Design decisions
 
-`enable-swift-package-manager: false` in `pubspec.yaml`: `google_mobile_ads`
-does not yet support SPM and conflicts with CocoaPods. Remove when resolved.
+- State management: `setState` is sufficient. Riverpod is over-engineering for this app's scale.
+  Each screen owns its own state; inter-screen data is passed via DTOs.


### PR DESCRIPTION
## 変更仕様

Claude Code がこのリポジトリで作業する際に参照できる情報が追加されます。
今後 AI エージェントが CLAUDE.md を読んで、ビルド手順・設計方針・環境設定を
人間に確認せず把握できるようになります。

## 変更内容

- `CLAUDE.md` — 技術スタック、ソースレイアウト、ビルド手順、アーキテクチャ方針
  （setState ベースの状態管理・エントリポイントをシンに保つ指針）、環境設定、既知の回避策
- `.claude/commands/upgrade-flutter-native-pkg.md` — CocoaPods 依存パッケージの
  アップグレード専用スキル
- `.gitignore` — `.claude/settings.local.json` を追跡対象外に追加