### PR TITLE
fix: SPM 移行後に Crashlytics dSYM アップロードが失敗する iOS ビルドエラーを修正する

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n$PODS_ROOT/FirebaseCrashlytics/run\n";
+			shellScript = "if [ -f \"${PODS_ROOT}/FirebaseCrashlytics/run\" ]; then\n  \"${PODS_ROOT}/FirebaseCrashlytics/run\"\nelse\n  \"${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nfi\n";
 		};
 		67950AD227B5F9B900263B03 /* Set Firebase Config */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## 変更仕様

PR #122 以前は iOS ビルドの CI が成功していたが、この PR 以降は Crashlytics dSYM のアップロードに CocoaPods パスではなく SPM パスが使われるようになる。

CocoaPods 環境とSPM 環境の両方で動作する Hybrid スクリプトのため、ローカルビルドの動作は変わらない。

## 混入過程

PR #122（`chore/upgrade-google-mobile-ads-for-spm`）で `enable-swift-package-manager: false` を削除したことで Firebase プラグインが CocoaPods から SPM 管理に移行した。その副作用として `Pods/FirebaseCrashlytics/` が CI で生成されなくなり、Xcode の "Upload Crashlytics dSYM" ビルドフェーズが古い CocoaPods パスを参照し続けてアーカイブに失敗するようになった。

`google_mobile_ads` の SPM 対応を目的とした意図的な変更だったが、Crashlytics dSYM スクリプトへの副作用を見落としていた。

## 変更内容

`ios/Runner.xcodeproj/project.pbxproj` の "Upload Crashlytics dSYM" ビルドフェーズを Hybrid スクリプトに更新する。

```
Before: $PODS_ROOT/FirebaseCrashlytics/run

After:
if [ -f "${PODS_ROOT}/FirebaseCrashlytics/run" ]; then
  "${PODS_ROOT}/FirebaseCrashlytics/run"
else
  "${BUILD_DIR%Build/*}SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run"
fi
```

- CocoaPods 環境では既存の `${PODS_ROOT}` パスを使用する
- SPM 環境では Firebase 公式推奨の `SourcePackages/checkouts` パスにフォールバックする

🤖 Generated with [Claude Code](https://claude.com/claude-code)